### PR TITLE
fix apt lock issue

### DIFF
--- a/terraform/cloud-init/ubuntu.sh
+++ b/terraform/cloud-init/ubuntu.sh
@@ -3,6 +3,14 @@
 # Add OKE repo & install the package
 add-apt-repository -y 'deb [trusted=yes] https://odx-oke.objectstorage.us-sanjose-1.oci.customer-oci.com/n/odx-oke/b/okn-repositories/o/prod/ubuntu-jammy/kubernetes-1.29 stable main'
 
+while fuser /var/lib/apt/lists/lock >/dev/null 2>&1 ; do
+    echo "Waiting for other apt instances to exit"
+    # Sleep to avoid pegging a CPU core while polling this lock
+    sleep 1
+done
+
+apt update
+
 apt install -y oci-oke-node-all*
 
 oke bootstrap --manage-gpu-services


### PR DESCRIPTION
On stand-alone instance deployment using the ubuntu image, the node fails to join the OKE cluster:

```
Adding disabled deb-src entry to /etc/apt/sources.list.d/archive_uri-https_odx-oke_objectstorage_us-sanjose-1_oci_customer-oci_c
om_n_odx-oke_b_okn-repositories_o_prod_ubuntu-jammy_kubernetes-1_29-jammy.list
Reading package lists...
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 1868 (apt)
E: Unable to lock directory /var/lib/apt/lists/
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package oci-oke-node-all*
```

Adding loop to wait for the release of apt lock.