### PR TITLE
Fix the Nvme RAID mount issue that causes nodes to be in NotReady status when rebooted

### DIFF
--- a/files/oke-nvme-raid.sh
+++ b/files/oke-nvme-raid.sh
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env bash
 # shellcheck disable=SC2086,SC2174
 set -o errexit -o nounset -o pipefail -x
@@ -6,7 +7,8 @@ shopt -s nullglob
 level="${1:-0}"
 pattern="${2:-/dev/nvme*n1}"
 mount_primary="${3:-/mnt/nvme}"
-mount_extra=(/var/lib/{containers,kubelet,openebs})
+mount_extra=(/var/lib/{containers,kubelet,logs/pods})
+md_device="/dev/md/0"
 
 # Enumerate NVMe devices, exit if absent
 devices=($pattern)
@@ -27,34 +29,57 @@ stripe=$((eff_count*stride)) # number of data disks * stride
 echo -e "Creating RAID${level} filesystem mounted under ${mount_primary} with $count devices:\n  ${devices[*]}" >&2
 echo -e "Filesystem options:\n  eff_count=$eff_count; chunk=${chunk}K; bs=${bs}K; stride=$stride; stripe-width=${stripe}" >&2
 shopt -u nullglob; seen_arrays=(/dev/md/*); device=${seen_arrays[0]}
-if [ ! -e "$device" ]; then
-  device="/dev/md/0"
-  echo "y" | mdadm --create "$device" --level="$level" --chunk=$chunk --force --raid-devices="$count" "${devices[@]}"
-  dd if=/dev/zero of="$device" bs=${bs}K count=128
+if [ ! -e "$md_device" ]; then
+  echo "y" | mdadm --create "$md_device" --level="$level" --chunk=$chunk --force --raid-devices="$count" "${devices[@]}"
+  dd if=/dev/zero of="$md_device" bs=${bs}K count=128
 else
-  echo "$device already initialized" >&2
+  echo "$md_device already initialized" >&2
 fi
 
-if ! tune2fs -l "$device" &>/dev/null; then
-  echo "Formatting '$device'" >&2
-  mkfs.ext4 -I 512 -b $((bs*1024)) -E stride=${stride},stripe-width=${stripe} -O dir_index -m 1 -F "$device"
+if ! tune2fs -l "$md_device" &>/dev/null; then
+  echo "Formatting '$md_device'" >&2
+  mkfs.ext4 -I 512 -b $((bs*1024)) -E stride=${stride},stripe-width=${stripe} -O dir_index -m 1 -F "$md_device"
 else
-  echo "$device already formatted" >&2
+  echo "$md_device already formatted" >&2
 fi
 
 mkdir -m 0755 -p "$mount_primary" "${mount_extra[@]}"
-mountpoint -q "$mount_primary" || mount -v -o rw,noatime,nofail "$device" "$mount_primary" || :
-grep -v "$mount_primary" /etc/fstab > /etc/fstab.new
-echo "$device $mount_primary ext4 rw,noatime,nofail 0 2" | tee -a /etc/fstab.new
+dev_uuid=$(blkid -s UUID -o value "${md_device}")
+mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_primary}")"
+cat > "/etc/systemd/system/${mount_unit_name}" << EOF
+    [Unit]
+    Description=Mount local NVMe RAID for OKE
+    [Mount]
+    What=UUID=${dev_uuid}
+    Where=${mount_primary}
+    Type=ext4
+    Options=defaults,noatime
+    [Install]
+    WantedBy=multi-user.target
+EOF
+  systemd-analyze verify "${mount_unit_name}"
+  systemctl enable "${mount_unit_name}" --now
 
 for mount in "${mount_extra[@]}"; do
   name=$(basename "$mount")
+  array_mount_point_name="$mount_primary/$name"
   mkdir -m 0755 -p "$mount_primary/$name"
-  mountpoint -q "$mount" || mount -vB "$mount_primary/$name" "$mount" || :
-  echo "$mount_primary $mount none defaults,bind 0 2" | tee -a /etc/fstab.new
+  mount_unit_name="$(systemd-escape --path --suffix=mount "${mount}")"
+  cat > "/etc/systemd/system/${mount_unit_name}" << EOF
+      [Unit]
+      Description=Mount ${name} on OKE NVMe RAID
+      [Mount]
+      What=${array_mount_point_name}
+      Where=${mount}
+      Type=none
+      Options=bind
+      [Install]
+      WantedBy=multi-user.target
+EOF
+    systemd-analyze verify "${mount_unit_name}"
+    systemctl enable "${mount_unit_name}" --now  
 done
 
-mv -v /etc/fstab.new /etc/fstab # update persisted filesystem mounts
 mdadm --detail --scan --verbose >> /etc/mdadm/mdadm.conf
 
 update-initramfs -u


### PR DESCRIPTION
Switch from using `/etc/fstab` to creating `systemd` units to fix the Nvme RAID mount issue that causes nodes to be in NotReady status when rebooted.