### PR TITLE
Fixes false postive WPA warning on BM nodes that are not listed for conditional check

### DIFF
--- a/manifests/node-problem-detector/values.yaml
+++ b/manifests/node-problem-detector/values.yaml
@@ -1078,11 +1078,6 @@ settings:
       def check_wpa_auth(metadata):
           shape = metadata.get('shape')
       
-          # Skip the test for VM shapes
-          if shape.startswith("VM."):
-              pass
-              return []
-      
           if shape in ["BM.GPU.H100.8", "BM.GPU.B4.8", "BM.GPU.A100-v2.8", "BM.GPU4.8"]:
               interface_range = range(16)
               required_authenticated = 16
@@ -1091,7 +1086,7 @@ settings:
               required_authenticated = 8
           else:
               logger.error("Unsupported machine shape.")
-              return ["Unsupported machine shape."]
+              return []
           
           authenticated_count = 0 
           wpa_auth_issues = []


### PR DESCRIPTION
Fixes false positive on L40s (and probably other BM shapes) with WPA errors. 

Return for check when BM shapes that are not explicitly listed should be the same for VMs and return an empty list. Previously it return a string stating that the shape was unsupported. That string was being resulted in the false positive. 

Conditional now returns an empty list, VMs specific conditional was removed as it is now redundent.