### PR TITLE
Add retry function to cloud init

### DIFF
--- a/files/oke-ubuntu-cloud-init.sh
+++ b/files/oke-ubuntu-cloud-init.sh
@@ -86,7 +86,7 @@ download_oke_credential_provider_for_ocir() {
     fi
 }
 
-# Wait until the certificate for instance principals is available in IMDS
+# Wait until the certificate for instance principal is available in IMDS
 until curl -fsSL -H "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/identity/cert.pem | grep -q "BEGIN CERTIFICATE"; do sleep 2; done
 
 # Disable nvidia-imex.service for GB200 and GB300 shapes for Dynamic Resource Allocation (DRA) compatibility


### PR DESCRIPTION
- Wait until instance principal certificate is available in IMDS
- Retry `oke bootstrap` if it fails.