### PR TITLE
Fix: Set to retentionSize for Prometheus 

### DIFF
--- a/terraform/files/kube-prometheus/values.yaml
+++ b/terraform/files/kube-prometheus/values.yaml
@@ -7,7 +7,8 @@ defaultRules:
 prometheus:
   prometheusSpec:
     enableAdminAPI: false
-    retention: 30d                         
+    retention: 30d
+    retentionSize: 450GB    
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
@@ -23,7 +24,7 @@ prometheus:
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
-              storage: 100Gi
+              storage: 500Gi
 
 prometheus-node-exporter:
   prometheus:

--- a/terraform/files/kube-prometheus/values.yaml.tftpl
+++ b/terraform/files/kube-prometheus/values.yaml.tftpl
@@ -7,7 +7,8 @@ defaultRules:
 prometheus:
   prometheusSpec:
     enableAdminAPI: false
-    retention: 30d                         
+    retention: 30d
+    retentionSize: 450GB    
     serviceMonitorSelectorNilUsesHelmValues: false
     podMonitorSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false
@@ -23,7 +24,7 @@ prometheus:
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
-              storage: 100Gi
+              storage: 500Gi
 
 prometheus-node-exporter:
   prometheus:


### PR DESCRIPTION
Previously retentionSize was not set on Prometheus which made TSDB grow without bounds and thus pod running out of disk space. This now fixed. We set a safe default retentionSize to 50Gb less than PVC size. Increase PVC size to 500Gb to account for high cardinality metrics and allow us to provide metrics for 30d. 