### PR TITLE
cluster-health-checks

### DIFF
--- a/docs/running-cluster-healthchecks.md
+++ b/docs/running-cluster-healthchecks.md
@@ -1,0 +1,134 @@
+# Running cluster-healthchecks Workloads
+
+This chart deploys a **DaemonSet** that runs continuous passive checks on GPU nodes, managed by Terraform.
+
+## Prerequisites
+
+- Access to the Kubernetes cluster used by this stack.
+
+## Deploy via Terraform
+
+Set the following variables:
+
+- `install_cluster_healthchecks = true`
+- `cluster_healthchecks_image_repository = "iad.ocir.io/iduyx1qnmway/lens-metric-collector/oci-dr-hpc-v2"`
+- `cluster_healthchecks_image_tag = "cuda-12.6.0-1.0.103"`
+
+Optional:
+
+- `cluster_healthchecks_image_pull_secrets = ["cluster-healthchecks-ocir-secret"]` (if your OCIR repo requires auth)
+- `cluster_healthcheck_verbose`
+
+## Terraform Note
+
+Terraform creates the Object Storage bucket and passes its name/namespace into the Helm values automatically.
+
+## CLI Quick Actions
+
+Start active test:
+
+1. Set test name and apply the on-demand Job:
+
+```bash
+TESTNAME=mytest envsubst < manifests/cluster-health-checks/cluster-healthchecks-active-job.yaml | kubectl apply -f -
+```
+
+2. If Kueue is enabled and the Job is suspended, unsuspend it:
+
+```bash
+kubectl patch job cluster-healthchecks-active -n cluster-healthchecks -p '{"spec":{"suspend":false}}'
+```
+
+Stop passive test:
+
+1. Disable the Helm release via Terraform:
+
+```bash
+# in tfvars or UI
+install_cluster_healthchecks = false
+```
+
+2. Re-apply Terraform.
+
+Check results:
+
+1. List recent pods:
+
+```bash
+kubectl get pods -n cluster-healthchecks
+```
+
+2. View logs:
+
+```bash
+kubectl logs -n cluster-healthchecks -l app=cluster-healthchecks-passive --tail=200
+```
+
+## Node Label Controls
+
+Disable passive checks on specific nodes:
+
+```bash
+kubectl label node <node> cluster-healthchecks=disabled
+```
+
+Enable active checks only on labeled nodes:
+
+```bash
+kubectl label node <node> cluster-healthchecks-active=true
+```
+
+## Full Workflow
+
+Select nodes:
+
+1. List GPU nodes:
+
+```bash
+kubectl get nodes -l nvidia.com/gpu=true
+kubectl get nodes -l amd.com/gpu=true
+```
+
+2. (Optional) Exclude passive checks on specific nodes:
+
+```bash
+kubectl label node <node> cluster-healthchecks=disabled
+```
+
+3. (Required for active tests) Mark nodes eligible for active jobs:
+
+```bash
+kubectl label node <node> cluster-healthchecks-active=true
+```
+
+Install passive checks:
+
+1. Set `install_cluster_healthchecks = true` in your stack inputs.
+2. Apply Terraform.
+
+Active checks (on-demand):
+
+1. Set a test name and apply the Job manifest:
+
+```bash
+TESTNAME=mytest envsubst < manifests/cluster-health-checks/cluster-healthchecks-active-job.yaml | kubectl apply -f -
+```
+
+2. If Kueue is enabled and the Job is suspended, unsuspend it:
+
+```bash
+kubectl patch job cluster-healthchecks-active -n cluster-healthchecks -p '{"spec":{"suspend":false}}'
+```
+
+Disable passive checks:
+
+Option A: Disable all passive checks (remove the DaemonSet):
+
+1. Set `install_cluster_healthchecks = false`.
+2. Apply Terraform.
+
+Option B: Disable passive checks on specific nodes:
+
+```bash
+kubectl label node <node> cluster-healthchecks=disabled
+```

--- a/manifests/cluster-health-checks/cluster-healthchecks-active-job.yaml
+++ b/manifests/cluster-health-checks/cluster-healthchecks-active-job.yaml
@@ -1,0 +1,227 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: gpu-nvidia
+  namespace: cluster-healthchecks
+spec:
+  nodeLabels:
+    nvidia.com/gpu: "true"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: gpu-amd
+  namespace: cluster-healthchecks
+spec:
+  nodeLabels:
+    amd.com/gpu: "true"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-healthchecks-queue
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: ["cpu", "memory", "nvidia.com/gpu", "amd.com/gpu", "ephemeral-storage"]
+    flavors:
+    - name: gpu-nvidia
+      resources:
+      - name: cpu
+        nominalQuota: "100000"
+      - name: memory
+        nominalQuota: "100000Gi"
+      - name: nvidia.com/gpu
+        nominalQuota: "100000"
+      - name: ephemeral-storage
+        nominalQuota: "100000Gi"
+    - name: gpu-amd
+      resources:
+      - name: cpu
+        nominalQuota: "100000"
+      - name: memory
+        nominalQuota: "100000Gi"
+      - name: amd.com/gpu
+        nominalQuota: "100000"
+      - name: ephemeral-storage
+        nominalQuota: "100000Gi"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: cluster-healthchecks-local
+  namespace: cluster-healthchecks
+spec:
+  clusterQueue: cluster-healthchecks-queue
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-healthchecks-active
+  namespace: cluster-healthchecks
+  labels:
+    app.kubernetes.io/name: cluster-healthchecks
+    app.kubernetes.io/instance: cluster-healthchecks
+    app: cluster-healthchecks-active
+  annotations:
+    kueue.x-k8s.io/queue-name: "cluster-healthchecks-local"
+spec:
+  suspend: true
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: cluster-healthchecks-active
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+      restartPolicy: Never
+
+      volumes:
+      - name: results
+        hostPath:
+          path: "/tmp/cluster-healthcheck"
+          type: DirectoryOrCreate
+      - name: host-root
+        hostPath:
+          path: /
+          type: Directory
+      - name: host-dbus
+        hostPath:
+          path: /run/dbus/system_bus_socket
+          type: Socket
+      - name: host-run
+        hostPath:
+          path: /run
+          type: Directory
+
+      # imagePullSecrets:
+      # - name: cluster-healthchecks-ocir-secret
+
+      nodeSelector:
+        cluster-healthchecks-active: "true"
+
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: nvidia.com/gpu
+                operator: In
+                values: ["true"]
+            - matchExpressions:
+              - key: amd.com/gpu
+                operator: In
+                values: ["true"]
+
+      containers:
+      - name: main
+        image: iad.ocir.io/iduyx1qnmway/lens-metric-collector/oci-dr-hpc-v2:cuda-12.6.0-1.0.103
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          privileged: true
+        env:
+        - name: RESULTS_DIR
+          value: "/results"
+        - name: RESULTS_BUCKET
+          valueFrom:
+            configMapKeyRef:
+              name: cluster-healthchecks-results
+              key: bucketName
+              optional: true
+        - name: RESULTS_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: cluster-healthchecks-results
+              key: namespace
+              optional: true
+        - name: VERBOSE
+          value: "false"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: OCI_GO_SDK_DEBUG
+          value: info
+        volumeMounts:
+        - name: results
+          mountPath: "/results"
+        - name: host-root
+          mountPath: /host
+          readOnly: false
+        - name: host-run
+          mountPath: /host/run
+          readOnly: true
+        - name: host-dbus
+          mountPath: /run/dbus/system_bus_socket
+          readOnly: true
+        command: ["/bin/bash"]
+        args:
+        - "-lc"
+        - |
+          set -euo pipefail
+
+          # ---- OCI region auto-detect (must be BEFORE any OCI SDK/CLI call) ----
+          IMDS="http://169.254.169.254/opc/v2/instance"
+          HDR="Authorization: Bearer Oracle"
+
+          REGION_ID="$(curl -sfH "$HDR" "$IMDS/regionInfo/regionIdentifier" || true)"
+          if [ -z "$REGION_ID" ]; then
+            REGION_ID="$(curl -sfH "$HDR" "$IMDS/canonicalRegionName" || true)"
+          fi
+
+          REALM_KEY="$(curl -sfH "$HDR" "$IMDS/regionInfo/realmKey" || true)"
+          REALM_DOM="$(curl -sfH "$HDR" "$IMDS/regionInfo/realmDomainComponent" || true)"
+          REGION_KEY="$(curl -sfH "$HDR" "$IMDS/regionInfo/regionKey" || true)"
+
+          export OCI_REGION="${REGION_ID}"
+          export OCI_REGION_METADATA="{\"realmKey\":\"${REALM_KEY}\",\"realmDomainComponent\":\"${REALM_DOM}\",\"regionKey\":\"${REGION_KEY}\",\"regionIdentifier\":\"${REGION_ID}\"}"
+
+          echo "Detected OCI_REGION=${OCI_REGION}"
+          # -------------------------------------------------------------------
+
+          RESULTS_DIR="${RESULTS_DIR:-/results}"
+          if [ -z "${RESULTS_BUCKET:-}" ] || [ -z "${RESULTS_NAMESPACE:-}" ]; then
+            echo "ERROR: ConfigMap cluster-healthchecks-results missing bucketName/namespace"
+            exit 1
+          fi
+          BUCKET="${RESULTS_BUCKET}"
+          NAMESPACE="${RESULTS_NAMESPACE}"
+          TESTNAME="${TESTNAME}"
+          if [ -z "${TESTNAME}" ]; then
+            echo "ERROR: TESTNAME is empty; set TESTNAME in this manifest"
+            exit 1
+          fi
+          mkdir -p "${RESULTS_DIR}"
+
+          ts="$(date -u +%Y%m%dT%H%M%SZ)"
+
+          echo "=== Kueue Active Test start ts=${ts}"
+
+          # Always capture a verbose log, regardless of where the tool writes its own logs
+          VERBOSE_FLAG=""
+          if [ "${VERBOSE:-false}" = "true" ]; then
+            VERBOSE_FLAG="--verbose"
+          fi
+          {
+
+            oci-dr-hpc-v2 active-checks \
+              --container \
+              --test "${TESTNAME}" \
+              --output json \
+              --output-dir "${RESULTS_DIR}" \
+              ${VERBOSE_FLAG} \
+              --upload --bucket "${BUCKET}" --namespace "${NAMESPACE}" || true
+          }
+
+          echo "=== Files ==="
+          ls -lah "${RESULTS_DIR}" || true
+
+          echo "Sleeping 300 seconds for inspection..."
+          sleep 300

--- a/terraform/files/cluster-healthchecks/Chart.yaml
+++ b/terraform/files/cluster-healthchecks/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cluster-healthchecks
+description: Cluster health checks workload (daemonset)
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/terraform/files/cluster-healthchecks/templates/_helpers.tpl
+++ b/terraform/files/cluster-healthchecks/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "cluster-healthchecks.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cluster-healthchecks.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/terraform/files/cluster-healthchecks/templates/configmap.yaml
+++ b/terraform/files/cluster-healthchecks/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-healthchecks-results
+  labels:
+    app.kubernetes.io/name: {{ include "cluster-healthchecks.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  bucketName: {{ required "results.bucketName is required" .Values.results.bucketName | quote }}
+  namespace: {{ required "results.namespace is required" .Values.results.namespace | quote }}
+  mountPath: {{ .Values.results.mountPath | default "/results" | quote }}

--- a/terraform/files/cluster-healthchecks/templates/daemonset.yaml
+++ b/terraform/files/cluster-healthchecks/templates/daemonset.yaml
@@ -1,0 +1,138 @@
+{{- if .Values.passive.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "cluster-healthchecks.fullname" . }}-passive
+  labels:
+    app.kubernetes.io/name: {{ include "cluster-healthchecks.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app: cluster-healthchecks-passive
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app: cluster-healthchecks-passive
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app: cluster-healthchecks-passive
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      dnsConfig:
+        options:
+        - name: ndots
+          value: "1"
+      restartPolicy: Always
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.passive.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.passive.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.passive.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: results
+        hostPath:
+          path: {{ .Values.results.path | default "/tmp/cluster-healthcheck" | quote }}
+          type: DirectoryOrCreate
+      - name: host-root
+        hostPath:
+          path: /
+          type: Directory
+      - name: host-run
+        hostPath:
+          path: /run
+          type: Directory
+      - name: host-dbus
+        hostPath:
+          path: /run/dbus/system_bus_socket
+          type: Socket
+      containers:
+      - name: passive
+        image: "{{ required \"image.repository is required\" .Values.image.repository }}:{{ required \"image.tag is required\" .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          privileged: true
+        env:
+        - name: RESULTS_BUCKET
+          valueFrom:
+            configMapKeyRef:
+              name: cluster-healthchecks-results
+              key: bucketName
+        - name: RESULTS_NAMESPACE
+          valueFrom:
+            configMapKeyRef:
+              name: cluster-healthchecks-results
+              key: namespace
+        - name: RESULTS_MOUNT_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: cluster-healthchecks-results
+              key: mountPath
+        command: ["/bin/bash","-lc"]
+        args:
+        - |-
+          set -euo pipefail
+
+          RESULTS_DIR="${RESULTS_MOUNT_PATH:-/results}"
+          BUCKET="${RESULTS_BUCKET}"
+          NAMESPACE="${RESULTS_NAMESPACE}"
+          if [ -z "${BUCKET}" ] || [ -z "${NAMESPACE}" ]; then
+            echo "ERROR: results.bucketName and results.namespace must be set"
+            exit 1
+          fi
+          mkdir -p "${RESULTS_DIR}"
+
+          echo "[passive] starting on $(hostname) at $(date -u +%Y%m%dT%H%M%SZ)"
+
+          while true; do
+            ts="$(date -u +%Y%m%dT%H%M%SZ)"
+
+            echo "[passive] tick ts=${ts}"
+
+            set +e
+            timeout -k 10 600 oci-dr-hpc-v2 health-checks --container \
+              -o json \
+              --output-dir "${RESULTS_DIR}" \
+              --all-recommendations \
+              {{- if .Values.passive.verbose }}--verbose{{ end }} \
+              --upload --bucket "${BUCKET}" --namespace "${NAMESPACE}"
+            rc=$?
+            set -e
+
+            sleep 300
+          done
+        volumeMounts:
+        - name: results
+          mountPath: {{ .Values.results.mountPath | default "/results" | quote }}
+        - name: host-root
+          mountPath: /host
+          readOnly: false
+        - name: host-run
+          mountPath: /host/run
+          readOnly: true
+        - name: host-dbus
+          mountPath: /run/dbus/system_bus_socket
+          readOnly: true
+{{- end }}

--- a/terraform/files/cluster-healthchecks/values.yaml
+++ b/terraform/files/cluster-healthchecks/values.yaml
@@ -1,0 +1,40 @@
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+commonLabels: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+passive:
+  enabled: true
+  nodeSelector: {}
+  tolerations: []
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: nvidia.com/gpu
+            operator: In
+            values: ["true"]
+          - key: cluster-healthchecks
+            operator: NotIn
+            values: ["disabled"]
+        - matchExpressions:
+          - key: amd.com/gpu
+            operator: In
+            values: ["true"]
+          - key: cluster-healthchecks
+            operator: NotIn
+            values: ["disabled"]
+  verbose: false
+
+results:
+  path: "/tmp/cluster-healthcheck"
+  mountPath: "/results"
+  bucketName: ""
+  namespace: ""

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -64,6 +64,7 @@ locals {
     "Allow dynamic-group %v to manage compute-management-family in compartment id %v",
     "Allow dynamic-group %v to manage instance-family in compartment id %v",
     "Allow dynamic-group %v to manage volume-family in compartment id %v",
+    var.install_cluster_healthchecks ? "Allow dynamic-group %v to manage object-family in compartment id %v" : "",
     "Allow dynamic-group %v to use ons-topics in compartment id %v",
     "Allow dynamic-group %v to use subnets in compartment id %v",
     "Allow dynamic-group %v to use virtual-network-family in compartment id %v",

--- a/terraform/object-storage.tf
+++ b/terraform/object-storage.tf
@@ -1,0 +1,22 @@
+# Copyright (c) 2025 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+data "oci_objectstorage_namespace" "cluster_healthchecks" {
+  count          = var.install_cluster_healthchecks ? 1 : 0
+  compartment_id = var.tenancy_ocid
+}
+
+resource "oci_objectstorage_bucket" "cluster_healthchecks" {
+  count          = var.install_cluster_healthchecks ? 1 : 0
+  compartment_id = var.compartment_ocid
+  namespace      = one(data.oci_objectstorage_namespace.cluster_healthchecks[*].namespace)
+  name           = format("cluster-health-checks-%s", local.state_id)
+  access_type    = "NoPublicAccess"
+  storage_tier   = "Standard"
+  versioning     = "Disabled"
+}
+
+locals {
+  cluster_healthchecks_results_bucket_name = try(one(oci_objectstorage_bucket.cluster_healthchecks[*].name), null)
+  cluster_healthchecks_results_namespace   = try(one(data.oci_objectstorage_namespace.cluster_healthchecks[*].namespace), null)
+}

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -87,6 +87,14 @@ output "grafana_port_forward" {
   value = format("kubectl port-forward -n %v svc/kube-prometheus-stack-grafana 3000:80", var.monitoring_namespace)
 }
 
+output "cluster_healthchecks_bucket_name" {
+  value = local.cluster_healthchecks_results_bucket_name
+}
+
+output "cluster_healthchecks_namespace" {
+  value = local.cluster_healthchecks_results_namespace
+}
+
 output "access_k8s_public_endpoint" {
   value = var.control_plane_is_public ? format("oci ce cluster create-kubeconfig --cluster-id %v --file $HOME/.kube/config --region %v --token-version 2.0.0 --kube-endpoint PUBLIC_ENDPOINT", module.oke.cluster_id, var.region) : "N/A"
 }

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -255,6 +255,11 @@ variableGroups:
     - install_grafana_dashboards
     - use_lets_encrypt_prod_endpoint
     - setup_alerting
+    - install_cluster_healthchecks
+    - cluster_healthchecks_namespace
+    - cluster_healthchecks_image_repository
+    - cluster_healthchecks_image_tag
+    - cluster_healthcheck_verbose
 
   - title: "Stack Configuration"
     variables:
@@ -1101,6 +1106,40 @@ variables:
       - monitoring_advanced_options
       - install_node_problem_detector_kube_prometheus_stack
       - install_grafana
+  install_cluster_healthchecks:
+    title: Install Cluster Healthchecks
+    description: Deploy the cluster-healthchecks daemonset.
+    type: boolean
+    default: true
+    visible: true
+  cluster_healthchecks_namespace:
+    title: Cluster Healthchecks namespace
+    description: Kubernetes namespace for cluster-healthchecks resources.
+    type: string
+    default: "cluster-healthchecks"
+    pattern: "^[a-z]([-a-z0-9]*[a-z0-9])?$"
+    required: ${install_cluster_healthchecks}
+    visible: ${install_cluster_healthchecks}
+  cluster_healthchecks_image_repository:
+    title: Cluster Healthchecks image repository
+    description: Image repository for the cluster-healthchecks workloads.
+    type: string
+    default: "iad.ocir.io/iduyx1qnmway/lens-metric-collector/oci-dr-hpc-v2"
+    required: ${install_cluster_healthchecks}
+    visible: ${install_cluster_healthchecks}
+  cluster_healthchecks_image_tag:
+    title: Cluster Healthchecks image tag
+    description: Image tag for the cluster-healthchecks workloads.
+    type: string
+    default: "cuda-12.6.0-1.0.103"
+    required: ${install_cluster_healthchecks}
+    visible: ${install_cluster_healthchecks}
+  cluster_healthcheck_verbose:
+    title: Cluster Healthchecks verbose
+    description: Enable verbose output for passive checks.
+    type: boolean
+    default: false
+    visible: ${install_cluster_healthchecks}
   avoid_waiting_for_delete_target:
     type: boolean
     title: Accelerate Oracle Notifications Service (ONS) topic deletion on stack destroy

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -315,6 +315,41 @@ variable "setup_alerting" {
   type    = bool
 }
 
+variable "install_cluster_healthchecks" {
+  default = true
+  type    = bool
+}
+
+variable "cluster_healthchecks_namespace" {
+  default = "cluster-healthchecks"
+  type    = string
+}
+
+variable "cluster_healthchecks_image_repository" {
+  default = "iad.ocir.io/iduyx1qnmway/lens-metric-collector/oci-dr-hpc-v2"
+  type    = string
+}
+
+variable "cluster_healthchecks_image_tag" {
+  default = "cuda-12.6.0-1.0.103"
+  type    = string
+}
+
+variable "cluster_healthchecks_image_pull_policy" {
+  default = "IfNotPresent"
+  type    = string
+}
+
+variable "cluster_healthchecks_image_pull_secrets" {
+  default = []
+  type    = list(string)
+}
+
+variable "cluster_healthcheck_verbose" {
+  default = false
+  type    = bool
+}
+
 variable "avoid_waiting_for_delete_target" {
   default = false
   type    = bool

--- a/terraform/via-operator-helm-deployments.tf
+++ b/terraform/via-operator-helm-deployments.tf
@@ -181,6 +181,51 @@ module "node_problem_detector" {
   depends_on = [module.kube_prometheus_stack]
 }
 
+module "cluster_healthchecks" {
+  count  = alltrue([local.deploy_from_operator, var.install_cluster_healthchecks]) ? 1 : 0
+  source = "./helm-module"
+
+  bastion_host    = module.oke.bastion_public_ip
+  bastion_user    = var.bastion_user
+  operator_host   = module.oke.operator_private_ip
+  operator_user   = var.operator_user
+  ssh_private_key = tls_private_key.stack_key.private_key_openssh
+
+  deployment_name = "cluster-healthchecks"
+  namespace       = var.cluster_healthchecks_namespace
+  helm_chart_path = "${path.module}/files/cluster-healthchecks"
+
+  pre_deployment_commands = [
+    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export OCI_CLI_AUTH=instance_principal"
+  ]
+  post_deployment_commands = []
+
+  deployment_extra_args = ["--wait"]
+
+  helm_template_values_override = yamlencode(
+    {
+      image = {
+        repository = var.cluster_healthchecks_image_repository
+        tag        = var.cluster_healthchecks_image_tag
+        pullPolicy = var.cluster_healthchecks_image_pull_policy
+        pullSecrets = [for s in var.cluster_healthchecks_image_pull_secrets : { name = s }]
+      }
+      passive = {
+        enabled  = true
+        verbose  = var.cluster_healthcheck_verbose
+      }
+      results = {
+        mountPath  = "/results"
+        bucketName = local.cluster_healthchecks_results_bucket_name
+        namespace  = local.cluster_healthchecks_results_namespace
+      }
+    }
+  )
+  helm_user_values_override = ""
+
+  depends_on = [module.oke]
+}
 
 module "nvidia_dcgm_exporter" {
   count  = alltrue([var.install_monitoring, local.deploy_from_operator, var.install_node_problem_detector_kube_prometheus_stack, var.install_nvidia_dcgm_exporter]) ? 1 : 0

--- a/terraform/via-provider-cluster-healthchecks.tf
+++ b/terraform/via-provider-cluster-healthchecks.tf
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+resource "helm_release" "cluster_healthchecks" {
+  count = alltrue([var.install_cluster_healthchecks, local.deploy_from_local || local.deploy_from_orm]) ? 1 : 0
+
+  name             = "cluster-healthchecks"
+  namespace        = var.cluster_healthchecks_namespace
+  chart            = "${path.module}/files/cluster-healthchecks"
+  create_namespace = true
+  force_update     = true
+  wait             = true
+  max_history      = 1
+
+  values = [
+    yamlencode(
+      {
+        image = {
+          repository = var.cluster_healthchecks_image_repository
+          tag        = var.cluster_healthchecks_image_tag
+          pullPolicy = var.cluster_healthchecks_image_pull_policy
+          pullSecrets = [for s in var.cluster_healthchecks_image_pull_secrets : { name = s }]
+        }
+        passive = {
+          enabled  = true
+          verbose  = var.cluster_healthcheck_verbose
+        }
+        results = {
+          mountPath  = "/results"
+          bucketName = local.cluster_healthchecks_results_bucket_name
+          namespace  = local.cluster_healthchecks_results_namespace
+        }
+      }
+    )
+  ]
+}


### PR DESCRIPTION
## Passive Tests (DaemonSet – continuous)

  Purpose: Always‑on health checks running on GPU nodes.

  How it starts

  1. Terraform apply with:
      - install_cluster_healthchecks = true
  2. Terraform installs Helm chart.
  3. Helm creates:
      - DaemonSet (runs on GPU nodes)
      - ConfigMap cluster-healthchecks-results containing bucket/namespace

  Where it runs

  - All GPU nodes except nodes labeled:

    kubectl label node <node> cluster-healthchecks=disabled

  What it does

  - Each pod loops:
      - runs oci-dr-hpc-v2 health-checks
      - uploads results to bucket/namespace from ConfigMap
      - sleeps 300 seconds

  How to stop

  - Disable all: set install_cluster_healthchecks = false and re‑apply Terraform
  - Disable per node: label node cluster-healthchecks=disabled

  ———

  ## Active Tests (Job – on demand)

  Purpose: Manual, one‑off tests triggered by customer.

  How it starts

  1. Customer sets a test name and applies the Job manifest:

     TESTNAME=mytest \
     envsubst < manifests/cluster-health-checks/cluster-healthchecks-active-job.yaml | kubectl apply -f -
  2. Job reads bucket/namespace from ConfigMap automatically.

  Where it runs

  - Only nodes labeled:

    kubectl label node <node> cluster-healthchecks-active=true

  How it runs

  - Job is suspended initially (Kueue‑style).
  - Customer unsuspends:

    kubectl patch job cluster-healthchecks-active -n cluster-healthchecks -p '{"spec":{"suspend":false}}'

  What it does

  - Runs oci-dr-hpc-v2 active-checks once
  - Uploads results to the ConfigMap bucket/namespace
  - Exits

  ———

  ## Quick Commands

  Label nodes

  kubectl label node <node> cluster-healthchecks=disabled
  kubectl label node <node> cluster-healthchecks-active=true

  Check logs

  kubectl logs -n cluster-healthchecks -l app=cluster-healthchecks-passive --tail=200
