### PR TITLE
Allow custom bastion and operator images

### DIFF
--- a/terraform/image.tf
+++ b/terraform/image.tf
@@ -2,7 +2,14 @@
 # Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
-  unique_image_urls = distinct(compact([var.worker_ops_image_custom_uri, var.worker_cpu_image_custom_uri, var.worker_gpu_image_custom_uri, var.worker_rdma_image_custom_uri]))
+  unique_image_urls = distinct(compact([
+    var.bastion_image_use_uri ? var.bastion_image_custom_uri : null,
+    var.operator_image_use_uri ? var.operator_image_custom_uri : null,
+    var.worker_ops_image_custom_uri,
+    var.worker_cpu_image_custom_uri,
+    var.worker_gpu_image_custom_uri,
+    var.worker_rdma_image_custom_uri
+  ]))
 }
 
 resource "oci_core_image" "imported_image" {

--- a/terraform/oke-addons.tf
+++ b/terraform/oke-addons.tf
@@ -192,10 +192,10 @@ resource "null_resource" "nvidia_dcgm_exporter_metrics_via_operator" {
     config_key      = local.nvidia_dcgm_exporter_metrics_filename
     namespace       = local.nvidia_gpu_operator_namespace
     bastion_host    = module.oke.bastion_public_ip
-    bastion_user    = var.bastion_user
+    bastion_user    = local.bastion_user
     ssh_private_key = tls_private_key.stack_key.private_key_openssh
     operator_host   = module.oke.operator_private_ip
-    operator_user   = var.operator_user
+    operator_user   = local.operator_user
     metrics_target  = "/tmp/${local.nvidia_dcgm_exporter_metrics_filename}"
   }
 

--- a/terraform/oke-cluster.tf
+++ b/terraform/oke-cluster.tf
@@ -196,6 +196,37 @@ locals {
     "VM.DenseIO.E4.Flex" = 16 * var.operator_shape_ocpus_denseIO_e4_flex,
     "VM.DenseIO.E5.Flex" = 12 * var.operator_shape_ocpus_denseIO_e5_flex
   }
+
+  bastion_image_type  = lower(var.bastion_image_type)
+  bastion_image_id    = var.bastion_image_use_uri ? lookup(lookup(oci_core_image.imported_image, var.bastion_image_custom_uri, {}), "id", null) : var.bastion_image_id
+  operator_image_type = lower(var.operator_image_type)
+  operator_image_id   = var.operator_image_use_uri ? lookup(lookup(oci_core_image.imported_image, var.operator_image_custom_uri, {}), "id", null) : var.operator_image_id
+
+  bastion_image_operating_system         = local.bastion_image_type == "custom" ? coalesce(try(one(data.oci_core_image.bastion_selected[*].operating_system), null), var.bastion_image_os) : var.bastion_image_os
+  bastion_image_operating_system_version = local.bastion_image_type == "custom" ? coalesce(try(one(data.oci_core_image.bastion_selected[*].operating_system_version), null), var.bastion_image_os_version) : var.bastion_image_os_version
+  operator_image_operating_system        = local.operator_image_type == "custom" ? coalesce(try(one(data.oci_core_image.operator_selected[*].operating_system), null), var.operator_image_os) : var.operator_image_os
+  operator_image_operating_system_version = local.operator_image_type == "custom" ? coalesce(
+    try(one(data.oci_core_image.operator_selected[*].operating_system_version), null),
+    var.operator_image_os_version
+  ) : var.operator_image_os_version
+  bastion_user = lower(var.bastion_user) == "auto" ? (
+    local.bastion_image_operating_system != null && can(regex("(?i)oracle.*linux", local.bastion_image_operating_system)) ? "opc" : "ubuntu"
+  ) : var.bastion_user
+  operator_user = lower(var.operator_user) == "auto" ? (
+    local.operator_image_operating_system != null && can(regex("(?i)oracle.*linux", local.operator_image_operating_system)) ? "opc" : "ubuntu"
+  ) : var.operator_user
+}
+
+data "oci_core_image" "bastion_selected" {
+  count = var.create_bastion && local.bastion_image_type == "custom" && (var.bastion_image_use_uri || coalesce(var.bastion_image_id, "none") != "none") ? 1 : 0
+
+  image_id = local.bastion_image_id
+}
+
+data "oci_core_image" "operator_selected" {
+  count = var.create_operator && local.operator_image_type == "custom" && (var.operator_image_use_uri || coalesce(var.operator_image_id, "none") != "none") ? 1 : 0
+
+  image_id = local.operator_image_id
 }
 
 module "oke" {
@@ -218,10 +249,11 @@ module "oke" {
   bastion_allowed_cidrs        = flatten(tolist([var.bastion_allowed_cidrs]))
   bastion_await_cloudinit      = false
   bastion_is_public            = var.create_public_subnets ? var.bastion_is_public : false
-  bastion_image_type           = var.bastion_image_type
-  bastion_image_os             = var.bastion_image_os
-  bastion_image_os_version     = var.bastion_image_os_version
-  bastion_user                 = var.bastion_user
+  bastion_image_type           = local.bastion_image_type
+  bastion_image_id             = local.bastion_image_id
+  bastion_image_os             = local.bastion_image_operating_system
+  bastion_image_os_version     = local.bastion_image_operating_system_version
+  bastion_user                 = local.bastion_user
   bastion_shape = {
     shape            = var.bastion_shape_name,
     ocpus            = var.bastion_shape_ocpus,
@@ -247,10 +279,11 @@ module "oke" {
   load_balancers                     = var.create_public_subnets ? "both" : "internal"
   lockdown_default_seclist           = true
   max_pods_per_node                  = var.max_pods_per_node
-  operator_image_type                = var.operator_image_type
-  operator_image_os                  = var.operator_image_os # Ignored when bastion_image_type = "custom"
-  operator_image_os_version          = var.operator_image_os_version
-  operator_user                      = var.operator_user
+  operator_image_type                = local.operator_image_type
+  operator_image_id                  = local.operator_image_id
+  operator_image_os                  = local.operator_image_operating_system
+  operator_image_os_version          = local.operator_image_operating_system_version
+  operator_user                      = local.operator_user
   operator_await_cloudinit           = local.any_deployments_via_operator ? true : false
   operator_install_kubectl_from_repo = true
   operator_install_helm_from_repo    = true

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -15,6 +15,26 @@ output "nat_route_table_id" { value = module.oke.nat_route_table_id }
 output "bastion_id" { value = module.oke.bastion_id }
 output "bastion_public_ip" { value = module.oke.bastion_public_ip }
 output "bastion_ssh_command" { value = var.create_bastion ? module.oke.ssh_to_bastion : "" }
+output "bastion_image_type" {
+  description = "Image selection mode used for the bastion instance."
+  value       = var.create_bastion ? local.bastion_image_type : ""
+}
+output "bastion_image_id" {
+  description = "Image OCID used for the bastion instance."
+  value       = var.create_bastion && local.bastion_image_id != null ? local.bastion_image_id : ""
+}
+output "bastion_image_os" {
+  description = "Operating system name for the bastion instance image."
+  value       = var.create_bastion ? coalesce(local.bastion_image_operating_system, "") : ""
+}
+output "bastion_image_os_version" {
+  description = "Operating system version for the bastion instance image."
+  value       = var.create_bastion ? coalesce(local.bastion_image_operating_system_version, "") : ""
+}
+output "bastion_ssh_user" {
+  description = "SSH username selected for the bastion instance."
+  value       = var.create_bastion ? local.bastion_user : ""
+}
 output "bastion_subnet_id" { value = module.oke.bastion_subnet_id }
 output "bastion_subnet_cidr" { value = module.oke.bastion_subnet_cidr }
 output "bastion_nsg_id" { value = module.oke.bastion_nsg_id }
@@ -53,6 +73,26 @@ output "bastion_service_worker_ssh_command" {
 output "operator_id" { value = module.oke.operator_id }
 output "operator_private_ip" { value = module.oke.operator_private_ip }
 output "operator_ssh_command" { value = var.create_operator ? module.oke.ssh_to_operator : "" }
+output "operator_image_type" {
+  description = "Image selection mode used for the operator instance."
+  value       = var.create_operator ? local.operator_image_type : ""
+}
+output "operator_image_id" {
+  description = "Image OCID used for the operator instance."
+  value       = var.create_operator && local.operator_image_id != null ? local.operator_image_id : ""
+}
+output "operator_image_os" {
+  description = "Operating system name for the operator instance image."
+  value       = var.create_operator ? coalesce(local.operator_image_operating_system, "") : ""
+}
+output "operator_image_os_version" {
+  description = "Operating system version for the operator instance image."
+  value       = var.create_operator ? coalesce(local.operator_image_operating_system_version, "") : ""
+}
+output "operator_ssh_user" {
+  description = "SSH username selected for the operator instance."
+  value       = var.create_operator ? local.operator_user : ""
+}
 output "operator_subnet_id" { value = module.oke.operator_subnet_id }
 output "operator_subnet_cidr" { value = module.oke.operator_subnet_cidr }
 output "operator_nsg_id" { value = module.oke.operator_nsg_id }

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -20,18 +20,6 @@ variableGroups:
       - current_user_ocid
       - tenancy_ocid
       - region
-      # Bastion variables
-      - bastion_image_id
-      - bastion_image_os
-      - bastion_image_os_version
-      - bastion_image_type
-      - bastion_user
-      # Operator variables
-      - operator_image_id
-      - operator_image_os
-      - operator_image_os_version
-      - operator_image_type
-      - operator_user
       # Storage
       - lustre_cluster_placement_group_id
       - lustre_file_system_name
@@ -135,6 +123,14 @@ variableGroups:
       - bastion_shape_name
       - bastion_shape_ocpus
       - bastion_shape_memory
+      - bastion_image_type
+      - bastion_image_os
+      - bastion_image_os_version
+      - bastion_image_use_uri
+      - bastion_image_custom_uri
+      - bastion_image_compartment
+      - bastion_image_id
+      - bastion_user
       - create_operator
       - operator_shape_config
       - operator_shape_name
@@ -143,6 +139,14 @@ variableGroups:
       - operator_shape_ocpus_denseIO_e5_flex
       - operator_shape_memory
       - operator_shape_boot
+      - operator_image_type
+      - operator_image_os
+      - operator_image_os_version
+      - operator_image_use_uri
+      - operator_image_custom_uri
+      - operator_image_compartment
+      - operator_image_id
+      - operator_user
       - create_oci_bastion_service
       - bastion_service_allowed_cidrs
       - bastion_service_max_session_ttl
@@ -828,6 +832,93 @@ variables:
           - eq: [bastion_shape_name, "VM.Standard.Ampere.Generic"]
           - eq: [bastion_shape_name, "VM.Standard.Intel.Generic"]
           - eq: [bastion_shape_name, "VM.Standard.E3.Flex"]
+  bastion_image_type:
+    title: Bastion image type
+    description: Use the latest platform image for the selected OS and version, select an image OCID, or import a custom image from an Object Storage URI.
+    type: enum
+    default: Platform
+    enum: [Platform, Custom]
+    required: true
+    visible:
+      and:
+        - ${create_bastion}
+        - ${bastion_shape_config}
+  bastion_image_os:
+    title: Bastion operating system
+    type: enum
+    default: "Canonical Ubuntu"
+    enum: ["Canonical Ubuntu"]
+    required: true
+    visible:
+      and:
+        - ${create_bastion}
+        - ${bastion_shape_config}
+        - eq: [bastion_image_type, Platform]
+  bastion_image_os_version:
+    title: Bastion operating system version
+    type: enum
+    default: "22.04"
+    enum: ["22.04", "24.04"]
+    required: true
+    visible:
+      and:
+        - ${create_bastion}
+        - ${bastion_shape_config}
+        - eq: [bastion_image_type, Platform]
+  bastion_image_use_uri:
+    title: Import custom image from URI
+    type: boolean
+    default: false
+    visible:
+      and:
+        - ${create_bastion}
+        - ${bastion_shape_config}
+        - eq: [bastion_image_type, Custom]
+  bastion_image_custom_uri:
+    title: Bastion image URI
+    type: string
+    pattern: "^(http|https)://.+"
+    required: true
+    visible:
+      and:
+        - ${create_bastion}
+        - ${bastion_shape_config}
+        - eq: [bastion_image_type, Custom]
+        - ${bastion_image_use_uri}
+  bastion_image_compartment:
+    title: Bastion image compartment
+    type: oci:identity:compartment:id
+    required: true
+    default: ${compartment_ocid}
+    visible:
+      and:
+        - ${create_bastion}
+        - ${bastion_shape_config}
+        - eq: [bastion_image_type, Custom]
+        - not: [bastion_image_use_uri]
+  bastion_image_id:
+    title: Bastion image
+    type: oci:core:image:id
+    required: true
+    dependsOn:
+      compartmentId: ${bastion_image_compartment}
+    visible:
+      and:
+        - ${create_bastion}
+        - ${bastion_shape_config}
+        - eq: [bastion_image_type, Custom]
+        - not: [bastion_image_use_uri]
+  bastion_user:
+    title: Bastion SSH user
+    description: SSH user for the bastion image. Use auto to select opc for Oracle Linux images and ubuntu for all other images, or override with your own username.
+    type: string
+    pattern: "^(auto|AUTO|Auto|[a-z_][a-z0-9_-]{0,31})$"
+    required: true
+    default: "auto"
+    visible:
+      and:
+        - ${create_bastion}
+        - ${bastion_shape_config}
 
   # Bastion Service
   create_oci_bastion_service:
@@ -975,6 +1066,93 @@ variables:
       and:
       - create_operator
       - operator_shape_config
+  operator_image_type:
+    title: Operator image type
+    description: Use the latest platform image for the selected OS and version, select an image OCID, or import a custom image from an Object Storage URI.
+    type: enum
+    default: Platform
+    enum: [Platform, Custom]
+    required: true
+    visible:
+      and:
+        - ${create_operator}
+        - ${operator_shape_config}
+  operator_image_os:
+    title: Operator operating system
+    type: enum
+    default: "Canonical Ubuntu"
+    enum: ["Canonical Ubuntu"]
+    required: true
+    visible:
+      and:
+        - ${create_operator}
+        - ${operator_shape_config}
+        - eq: [operator_image_type, Platform]
+  operator_image_os_version:
+    title: Operator operating system version
+    type: enum
+    default: "22.04"
+    enum: ["22.04", "24.04"]
+    required: true
+    visible:
+      and:
+        - ${create_operator}
+        - ${operator_shape_config}
+        - eq: [operator_image_type, Platform]
+  operator_image_use_uri:
+    title: Import custom image from URI
+    type: boolean
+    default: false
+    visible:
+      and:
+        - ${create_operator}
+        - ${operator_shape_config}
+        - eq: [operator_image_type, Custom]
+  operator_image_custom_uri:
+    title: Operator image URI
+    type: string
+    pattern: "^(http|https)://.+"
+    required: true
+    visible:
+      and:
+        - ${create_operator}
+        - ${operator_shape_config}
+        - eq: [operator_image_type, Custom]
+        - ${operator_image_use_uri}
+  operator_image_compartment:
+    title: Operator image compartment
+    type: oci:identity:compartment:id
+    required: true
+    default: ${compartment_ocid}
+    visible:
+      and:
+        - ${create_operator}
+        - ${operator_shape_config}
+        - eq: [operator_image_type, Custom]
+        - not: [operator_image_use_uri]
+  operator_image_id:
+    title: Operator image
+    type: oci:core:image:id
+    required: true
+    dependsOn:
+      compartmentId: ${operator_image_compartment}
+    visible:
+      and:
+        - ${create_operator}
+        - ${operator_shape_config}
+        - eq: [operator_image_type, Custom]
+        - not: [operator_image_use_uri]
+  operator_user:
+    title: Operator SSH user
+    description: SSH user for the operator image. Use auto to select opc for Oracle Linux images and ubuntu for all other images, or override with your own username.
+    type: string
+    pattern: "^(auto|AUTO|Auto|[a-z_][a-z0-9_-]{0,31})$"
+    required: true
+    default: "auto"
+    visible:
+      and:
+        - ${create_operator}
+        - ${operator_shape_config}
  
   # Storage
   create_fss:
@@ -2140,6 +2318,11 @@ outputGroups:
       - bastion_nsg_id
       - bastion_public_ip
       - bastion_ssh_command
+      - bastion_image_type
+      - bastion_image_id
+      - bastion_image_os
+      - bastion_image_os_version
+      - bastion_ssh_user
       - bastion_ssh_secret_id
 
   - title: Bastion Service
@@ -2159,6 +2342,11 @@ outputGroups:
       - operator_nsg_id
       - operator_private_ip
       - operator_ssh_command
+      - operator_image_type
+      - operator_image_id
+      - operator_image_os
+      - operator_image_os_version
+      - operator_ssh_user
 
 #  - title: File Storage Service (FSS)
 #    outputs:
@@ -2253,23 +2441,38 @@ outputs:
 
   # Bastion
   bastion_id:
-    title: Instance
+    title: Bastion instance OCID
     type: ocid
   bastion_subnet_id:
-    title: Subnet
+    title: Bastion subnet OCID
     type: ocid
   bastion_subnet_cidr:
-    title: Subnet CIDR
+    title: Bastion subnet CIDR
     type: string
   bastion_nsg_id:
-    title: Network security group
+    title: Bastion network security group OCID
     type: ocid
   bastion_public_ip:
-    title: Address
+    title: Bastion public IP address
     type: copyableString
   bastion_ssh_command:
-    title: SSH command
+    title: Bastion SSH command
     type: copyableString
+  bastion_image_type:
+    title: Bastion image type
+    type: string
+  bastion_image_id:
+    title: Bastion image OCID
+    type: ocid
+  bastion_image_os:
+    title: Bastion image operating system
+    type: string
+  bastion_image_os_version:
+    title: Bastion image operating system version
+    type: string
+  bastion_ssh_user:
+    title: Bastion SSH user
+    type: string
 
 # Bastion Service
   bastion_service_id:
@@ -2293,22 +2496,38 @@ outputs:
 
   # Operator
   operator_id:
-    title: Instance
+    title: Operator instance OCID
+    type: ocid
   operator_subnet_id:
-    title: Subnet
+    title: Operator subnet OCID
     type: ocid
   operator_subnet_cidr:
-    title: Subnet CIDR
+    title: Operator subnet CIDR
     type: string
   operator_nsg_id:
-    title: Network security group
+    title: Operator network security group OCID
     type: ocid
   operator_private_ip:
-    title: Address
+    title: Operator private IP address
     type: copyableString
   operator_ssh_command:
-    title: SSH command
+    title: Operator SSH command
     type: copyableString
+  operator_image_type:
+    title: Operator image type
+    type: string
+  operator_image_id:
+    title: Operator image OCID
+    type: ocid
+  operator_image_os:
+    title: Operator image operating system
+    type: string
+  operator_image_os_version:
+    title: Operator image operating system version
+    type: string
+  operator_ssh_user:
+    title: Operator SSH user
+    type: string
 
   # Cluster
   cluster_id:
@@ -2361,28 +2580,28 @@ outputs:
 
   # Workers
   worker_subnet_id:
-    title: Subnet
+    title: Worker subnet OCID
     type: ocid
   worker_subnet_cidr:
-    title: Subnet CIDR
+    title: Worker subnet CIDR
     type: string
   worker_nsg_id:
-    title: Network security group
+    title: Worker network security group OCID
     type: ocid
   worker_ops_pool_id:
   # Workers - System pool
-    title: System pool
+    title: System worker node pool OCID
     type: ocid
   worker_cpu_pool_id:
-    title: CPU pool
+    title: CPU worker node pool OCID
     type: ocid
     visible: ${worker_cpu_enabled}
   worker_gpu_pool_id:
-    title: GPU pool
+    title: GPU worker node pool OCID
     type: ocid
     visible: worker_gpu_enabled
   worker_rdma_pool_id:
-    title: RDMA pool
+    title: RDMA worker node pool OCID
     type: ocid
     visible: ${worker_rdma_enabled}
   

--- a/terraform/validation.tf
+++ b/terraform/validation.tf
@@ -7,11 +7,28 @@ locals {
   invalid_bastion                = !var.create_public_subnets && var.create_bastion
   invalid_worker_rdma_image      = can(regex("(?i)oracle.*linux", one(data.oci_core_image.worker_rdma[*].display_name)))
   invalid_grace_blackwell_shape  = contains(["BM.GPU.GB200.4", "BM.GPU.GB200-v2.4", "BM.GPU.GB200-v3.4", "BM.GPU.GB300.4"], var.worker_rdma_shape)
+  invalid_bastion_custom_image = var.create_bastion && local.bastion_image_type == "custom" && (
+    var.bastion_image_use_uri ? trimspace(coalesce(var.bastion_image_custom_uri, "none")) == "none" : trimspace(coalesce(var.bastion_image_id, "none")) == "none"
+  )
+  invalid_operator_custom_image = var.create_operator && local.operator_image_type == "custom" && (
+    var.operator_image_use_uri ? trimspace(coalesce(var.operator_image_custom_uri, "none")) == "none" : trimspace(coalesce(var.operator_image_id, "none")) == "none"
+  )
+  allowed_image_uri_prefixes = ["http://", "https://"]
+  image_uri_values = {
+    bastion     = lower(trimspace(coalesce(var.bastion_image_custom_uri, "none")))
+    operator    = lower(trimspace(coalesce(var.operator_image_custom_uri, "none")))
+    worker_ops  = lower(trimspace(coalesce(var.worker_ops_image_custom_uri, "none")))
+    worker_cpu  = lower(trimspace(coalesce(var.worker_cpu_image_custom_uri, "none")))
+    worker_gpu  = lower(trimspace(coalesce(var.worker_gpu_image_custom_uri, "none")))
+    worker_rdma = lower(trimspace(coalesce(var.worker_rdma_image_custom_uri, "none")))
+  }
   invalid_image_uri = anytrue([
-    var.worker_ops_image_use_uri && !startswith(coalesce(var.worker_ops_image_custom_uri, "none"), "http"),
-    var.worker_cpu_image_use_uri && !startswith(coalesce(var.worker_cpu_image_custom_uri, "none"), "http"),
-    var.worker_gpu_image_use_uri && !startswith(coalesce(var.worker_gpu_image_custom_uri, "none"), "http"),
-    var.worker_rdma_image_use_uri && !startswith(coalesce(var.worker_rdma_image_custom_uri, "none"), "http"),
+    var.bastion_image_use_uri && !anytrue([for prefix in local.allowed_image_uri_prefixes : startswith(local.image_uri_values.bastion, prefix)]),
+    var.operator_image_use_uri && !anytrue([for prefix in local.allowed_image_uri_prefixes : startswith(local.image_uri_values.operator, prefix)]),
+    var.worker_ops_image_use_uri && !anytrue([for prefix in local.allowed_image_uri_prefixes : startswith(local.image_uri_values.worker_ops, prefix)]),
+    var.worker_cpu_image_use_uri && !anytrue([for prefix in local.allowed_image_uri_prefixes : startswith(local.image_uri_values.worker_cpu, prefix)]),
+    var.worker_gpu_image_use_uri && !anytrue([for prefix in local.allowed_image_uri_prefixes : startswith(local.image_uri_values.worker_gpu, prefix)]),
+    var.worker_rdma_image_use_uri && !anytrue([for prefix in local.allowed_image_uri_prefixes : startswith(local.image_uri_values.worker_rdma, prefix)]),
   ])
 
   # Pods subnet capacity validation
@@ -110,12 +127,34 @@ resource "null_resource" "validate_worker_rdma_image" {
 }
 
 resource "null_resource" "validate_image_uri" {
-  count = anytrue([var.worker_ops_image_use_uri, var.worker_cpu_image_use_uri, var.worker_gpu_image_use_uri, var.worker_rdma_image_use_uri]) ? 1 : 0
+  count = anytrue([var.bastion_image_use_uri, var.operator_image_use_uri, var.worker_ops_image_use_uri, var.worker_cpu_image_use_uri, var.worker_gpu_image_use_uri, var.worker_rdma_image_use_uri]) ? 1 : 0
 
   lifecycle {
     precondition {
       condition     = !local.invalid_image_uri
-      error_message = "Error: Invalid image URI detected. Please ensure the URI is correct and accessible."
+      error_message = "Error: Invalid image URI detected. Image import URIs must start with http:// or https://."
+    }
+  }
+}
+
+resource "null_resource" "validate_bastion_image_selection" {
+  count = local.invalid_bastion_custom_image ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = !local.invalid_bastion_custom_image
+      error_message = "When bastion_image_type is custom, provide either bastion_image_id or enable bastion_image_use_uri with bastion_image_custom_uri."
+    }
+  }
+}
+
+resource "null_resource" "validate_operator_image_selection" {
+  count = local.invalid_operator_custom_image ? 1 : 0
+
+  lifecycle {
+    precondition {
+      condition     = !local.invalid_operator_custom_image
+      error_message = "When operator_image_type is custom, provide either operator_image_id or enable operator_image_use_uri with operator_image_custom_uri."
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -143,6 +143,11 @@ variable "bastion_image_type" {
   default     = "platform"
   description = "Whether to use a platform or custom image for the created bastion instance. When custom is set, the bastion_image_id must be specified."
   type        = string
+
+  validation {
+    condition     = contains(["platform", "custom"], lower(var.bastion_image_type))
+    error_message = "bastion_image_type must be either 'platform' or 'custom'."
+  }
 }
 variable "bastion_image_os" {
   default     = "Canonical Ubuntu"
@@ -159,10 +164,30 @@ variable "bastion_image_id" {
   description = "Image ID for created bastion instance."
   type        = string
 }
-variable "bastion_user" {
-  default     = "ubuntu"
-  description = "The user used to SSH into the bastion instance."
+variable "bastion_image_compartment" {
+  default     = null
+  description = "Compartment containing the selected bastion custom image."
   type        = string
+}
+variable "bastion_image_custom_uri" {
+  default     = null
+  description = "Object Storage URI used to import a custom image for the created bastion instance."
+  type        = string
+}
+variable "bastion_image_use_uri" {
+  default     = false
+  description = "Import the bastion custom image from an Object Storage URI."
+  type        = bool
+}
+variable "bastion_user" {
+  default     = "auto"
+  description = "The user used to SSH into the bastion instance. Set to 'auto' to use opc for Oracle Linux images and ubuntu for all other images, or override with your own username."
+  type        = string
+
+  validation {
+    condition     = lower(var.bastion_user) == "auto" || can(regex("^[a-z_][a-z0-9_-]{0,31}$", var.bastion_user))
+    error_message = "bastion_user must be 'auto' or a valid Linux username."
+  }
 }
 
 # Bastion Service
@@ -221,11 +246,36 @@ variable "operator_image_type" {
   default     = "platform"
   description = "Whether to use a platform or custom image for the created operator instance. When custom is set, the operator_image_id must be specified."
   type        = string
+
+  validation {
+    condition     = contains(["platform", "custom"], lower(var.operator_image_type))
+    error_message = "operator_image_type must be either 'platform' or 'custom'."
+  }
+}
+variable "operator_image_compartment" {
+  default     = null
+  description = "Compartment containing the selected operator custom image."
+  type        = string
+}
+variable "operator_image_custom_uri" {
+  default     = null
+  description = "Object Storage URI used to import a custom image for the created operator instance."
+  type        = string
+}
+variable "operator_image_use_uri" {
+  default     = false
+  description = "Import the operator custom image from an Object Storage URI."
+  type        = bool
 }
 variable "operator_user" {
-  default     = "ubuntu"
-  description = "The user used to SSH into the operator instance."
+  default     = "auto"
+  description = "The user used to SSH into the operator instance. Set to 'auto' to use opc for Oracle Linux images and ubuntu for all other images, or override with your own username."
   type        = string
+
+  validation {
+    condition     = lower(var.operator_user) == "auto" || can(regex("^[a-z_][a-z0-9_-]{0,31}$", var.operator_user))
+    error_message = "operator_user must be 'auto' or a valid Linux username."
+  }
 }
 
 # STORAGE

--- a/terraform/via-operator-fss.tf
+++ b/terraform/via-operator-fss.tf
@@ -7,10 +7,10 @@ resource "null_resource" "fss_pv_via_operator" {
   triggers = {
     volume_handle   = format("%v:%v:%s", oci_file_storage_file_system.fss.0.id, data.oci_core_private_ip.fss_mt_ip.0.ip_address, local.fss_export_path)
     bastion_host    = module.oke.bastion_public_ip
-    bastion_user    = var.bastion_user
+    bastion_user    = local.bastion_user
     ssh_private_key = tls_private_key.stack_key.private_key_openssh
     operator_host   = module.oke.operator_private_ip
-    operator_user   = var.operator_user
+    operator_user   = local.operator_user
   }
 
   connection {
@@ -26,7 +26,7 @@ resource "null_resource" "fss_pv_via_operator" {
 
   provisioner "remote-exec" {
     inline = [
-      "export PATH=$PATH:/usr/local/bin:/home/${var.operator_user}/bin",
+      "export PATH=$PATH:/usr/local/bin:/home/${local.operator_user}/bin",
       "export OCI_CLI_AUTH=instance_principal",
       "export PYTHONWARNINGS=\"ignore:the 'strict' parameter::urllib3.poolmanager\"",
       "for i in $(seq 1 30); do if [ -f ~/.kube/config ] && timeout 10 kubectl cluster-info >/dev/null 2>&1; then echo 'Kubeconfig is ready!'; break; else echo \"Waiting for kubeconfig... ($i/30)\"; sleep 10; fi; done",

--- a/terraform/via-operator-grafana.tf
+++ b/terraform/via-operator-grafana.tf
@@ -10,7 +10,7 @@ locals {
         {
           name      = "dashboard-${trimsuffix(cdk, ".json")}",
           namespace = var.monitoring_namespace,
-          files     = [join("/", ["/home/${var.operator_user}/grafana/dashboards/common", cdk])]
+          files     = [join("/", ["/home/${local.operator_user}/grafana/dashboards/common", cdk])]
           options = {
             labels = {
               grafana_dashboard = "1"
@@ -28,7 +28,7 @@ locals {
         {
           name      = "dashboard-${trimsuffix(cdk, ".json")}",
           namespace = var.monitoring_namespace,
-          files     = [join("/", ["/home/${var.operator_user}/grafana/dashboards/nvidia", cdk])]
+          files     = [join("/", ["/home/${local.operator_user}/grafana/dashboards/nvidia", cdk])]
           options = {
             labels = {
               grafana_dashboard = "1"
@@ -46,7 +46,7 @@ locals {
         {
           name      = "dashboard-${trimsuffix(cdk, ".json")}",
           namespace = var.monitoring_namespace,
-          files     = [join("/", ["/home/${var.operator_user}/grafana/dashboards/amd", cdk])]
+          files     = [join("/", ["/home/${local.operator_user}/grafana/dashboards/amd", cdk])]
           options = {
             labels = {
               grafana_dashboard = "1"
@@ -63,7 +63,7 @@ locals {
         {
           name      = "dashboard-${trimsuffix(cdk, ".json")}",
           namespace = var.monitoring_namespace,
-          files     = [join("/", ["/home/${var.operator_user}/grafana/dashboards/oci", cdk])]
+          files     = [join("/", ["/home/${local.operator_user}/grafana/dashboards/oci", cdk])]
           options = {
             labels = {
               grafana_dashboard = "1"
@@ -79,7 +79,7 @@ locals {
         {
           name      = "alert-${trimsuffix(cak, ".yaml")}",
           namespace = var.monitoring_namespace,
-          files     = [join("/", ["/home/${var.operator_user}/grafana/alerts", cak])]
+          files     = [join("/", ["/home/${local.operator_user}/grafana/alerts", cak])]
           options = {
             labels = {
               grafana_alert = "1"
@@ -99,10 +99,10 @@ resource "null_resource" "deploy_grafana_dashboards_and_alerts_from_operator" {
     manifest_md5    = sha256(join(".", [for entry in sort(flatten([local.grafana_common_dashboard_files_path, local.grafana_amd_dashboard_files_path, local.grafana_nvidia_dashboard_files_path, local.grafana_oci_dashboard_files_path, local.grafana_alert_files_path])) : filemd5(entry)]))
     namespace       = var.monitoring_namespace
     bastion_host    = module.oke.bastion_public_ip
-    bastion_user    = var.bastion_user
+    bastion_user    = local.bastion_user
     ssh_private_key = tls_private_key.stack_key.private_key_openssh
     operator_host   = module.oke.operator_private_ip
-    operator_user   = var.operator_user
+    operator_user   = local.operator_user
   }
 
 

--- a/terraform/via-operator-helm-deployments.tf
+++ b/terraform/via-operator-helm-deployments.tf
@@ -14,9 +14,9 @@ module "certmanager" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name     = "cert-manager"
@@ -26,7 +26,7 @@ module "certmanager" {
   helm_chart_version  = var.cert_manager_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal",
     "export PYTHONWARNINGS=\"ignore:the 'strict' parameter::urllib3.poolmanager\"",
     "grep -q 'parameter::urllib3.poolmanager' ~/.bashrc || cat >> ~/.bashrc <<'EOF'\nexport PYTHONWARNINGS=\"ignore:the 'strict' parameter::urllib3.poolmanager\"\nEOF",
@@ -65,9 +65,9 @@ module "ingress" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name     = "contour"
@@ -77,7 +77,7 @@ module "ingress" {
   helm_chart_version  = var.ingress_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal"
   ]
   post_deployment_commands = flatten([
@@ -111,9 +111,9 @@ module "kube_prometheus_stack" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name     = "kube-prometheus-stack"
@@ -123,7 +123,7 @@ module "kube_prometheus_stack" {
   helm_chart_version  = var.prometheus_stack_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal",
     "command -v jq >/dev/null 2>&1 || sudo bash -c 'apt-get update && apt-get install -y jq || yum install -y jq || dnf install -y jq'",
     "export INGRESS_IP=$(kubectl get svc -A -l app.kubernetes.io/name=contour  -o json | jq -r '.items[] | select(.spec.type == \"LoadBalancer\") | .status.loadBalancer.ingress[].ip')"
@@ -186,9 +186,9 @@ module "node_problem_detector" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name     = "gpu-rdma-node-problem-detector"
@@ -198,7 +198,7 @@ module "node_problem_detector" {
   helm_chart_version  = var.node_problem_detector_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal"
   ]
   deployment_extra_args    = ["--force", "--dependency-update", "--history-max 1"]
@@ -217,10 +217,10 @@ resource "null_resource" "nvidia_dcgm_exporter_service_monitor" {
   triggers = {
     manifest_md5    = md5(local.nvidia_dcgm_exporter_service_monitor_manifest)
     bastion_host    = module.oke.bastion_public_ip
-    bastion_user    = var.bastion_user
+    bastion_user    = local.bastion_user
     ssh_private_key = tls_private_key.stack_key.private_key_openssh
     operator_host   = module.oke.operator_private_ip
-    operator_user   = var.operator_user
+    operator_user   = local.operator_user
   }
 
   connection {
@@ -241,7 +241,7 @@ resource "null_resource" "nvidia_dcgm_exporter_service_monitor" {
 
   provisioner "remote-exec" {
     inline = [
-      "export PATH=$PATH:/usr/local/bin:/home/${var.operator_user}/bin",
+      "export PATH=$PATH:/usr/local/bin:/home/${local.operator_user}/bin",
       "export OCI_CLI_AUTH=instance_principal",
       "for i in $(seq 1 30); do if [ -f ~/.kube/config ] && timeout 10 kubectl cluster-info >/dev/null 2>&1; then echo 'Kubeconfig is ready!'; break; else echo \"Waiting for kubeconfig... ($i/30)\"; sleep 10; fi; done",
       "if ! timeout 30 kubectl cluster-info >/dev/null 2>&1; then echo 'ERROR: Kubeconfig not available after 5 minutes!'; exit 1; fi",
@@ -283,9 +283,9 @@ module "amd_device_metrics_exporter" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name     = "amd-device-metrics-exporter"
@@ -295,7 +295,7 @@ module "amd_device_metrics_exporter" {
   helm_chart_version  = var.amd_device_metrics_exporter_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal"
   ]
   deployment_extra_args    = ["--force", "--dependency-update", "--history-max 1"]
@@ -313,9 +313,9 @@ module "oke-ons-webhook" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name    = "oke-ons-webhook"
@@ -324,7 +324,7 @@ module "oke-ons-webhook" {
   helm_chart_version = var.oke_ons_webhook_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal"
   ]
   deployment_extra_args    = ["--force", "--dependency-update", "--history-max 1"]
@@ -350,9 +350,9 @@ module "oci_metrics_exporter" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name    = "oci-metrics-exporter"
@@ -361,7 +361,7 @@ module "oci_metrics_exporter" {
   helm_chart_version = var.oci_metrics_exporter_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal"
   ]
   deployment_extra_args    = ["--force", "--dependency-update", "--history-max 1"]

--- a/terraform/via-operator-kueue.tf
+++ b/terraform/via-operator-kueue.tf
@@ -6,9 +6,9 @@ module "kueue" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name     = "kueue"
@@ -18,7 +18,7 @@ module "kueue" {
   helm_chart_version  = var.kueue_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal",
     "export PYTHONWARNINGS=\"ignore:the 'strict' parameter::urllib3.poolmanager\""
   ]

--- a/terraform/via-operator-lustre.tf
+++ b/terraform/via-operator-lustre.tf
@@ -9,10 +9,10 @@ resource "null_resource" "lustre_pv_via_operator" {
     lustre_fs_name  = var.lustre_file_system_name
     lustre_size     = floor(var.lustre_size_in_tb)
     bastion_host    = module.oke.bastion_public_ip
-    bastion_user    = var.bastion_user
+    bastion_user    = local.bastion_user
     ssh_private_key = tls_private_key.stack_key.private_key_openssh
     operator_host   = module.oke.operator_private_ip
-    operator_user   = var.operator_user
+    operator_user   = local.operator_user
   }
 
   connection {
@@ -28,7 +28,7 @@ resource "null_resource" "lustre_pv_via_operator" {
 
   provisioner "remote-exec" {
     inline = [
-      "export PATH=$PATH:/usr/local/bin:/home/${var.operator_user}/bin",
+      "export PATH=$PATH:/usr/local/bin:/home/${local.operator_user}/bin",
       "export OCI_CLI_AUTH=instance_principal",
       "export PYTHONWARNINGS=\"ignore:the 'strict' parameter::urllib3.poolmanager\"",
       "for i in $(seq 1 30); do if [ -f ~/.kube/config ] && timeout 10 kubectl cluster-info >/dev/null 2>&1; then echo 'Kubeconfig is ready!'; break; else echo \"Waiting for kubeconfig... ($i/30)\"; sleep 10; fi; done",

--- a/terraform/via-operator-mpi-operator.tf
+++ b/terraform/via-operator-mpi-operator.tf
@@ -7,10 +7,10 @@ resource "null_resource" "mpi_operator" {
   triggers = {
     manifest_md5    = md5(file("${path.module}/files/mpi-operator/mpi-operator.yaml"))
     bastion_host    = module.oke.bastion_public_ip
-    bastion_user    = var.bastion_user
+    bastion_user    = local.bastion_user
     ssh_private_key = tls_private_key.stack_key.private_key_openssh
     operator_host   = module.oke.operator_private_ip
-    operator_user   = var.operator_user
+    operator_user   = local.operator_user
   }
 
   connection {
@@ -31,7 +31,7 @@ resource "null_resource" "mpi_operator" {
 
   provisioner "remote-exec" {
     inline = [
-      "export PATH=$PATH:/usr/local/bin:/home/${var.operator_user}/bin",
+      "export PATH=$PATH:/usr/local/bin:/home/${local.operator_user}/bin",
       "export OCI_CLI_AUTH=instance_principal",
       "export PYTHONWARNINGS=\"ignore:the 'strict' parameter::urllib3.poolmanager\"",
       "for i in $(seq 1 30); do if [ -f ~/.kube/config ] && timeout 10 kubectl cluster-info >/dev/null 2>&1; then echo 'Kubeconfig is ready!'; break; else echo \"Waiting for kubeconfig... ($i/30)\"; sleep 10; fi; done",

--- a/terraform/via-operator-nvidia-dra-driver.tf
+++ b/terraform/via-operator-nvidia-dra-driver.tf
@@ -6,9 +6,9 @@ module "nvidia_dra_driver" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name     = "dra-driver-nvidia-gpu"
@@ -18,7 +18,7 @@ module "nvidia_dra_driver" {
   helm_chart_version  = var.nvidia_dra_driver_chart_version
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal",
     "export PYTHONWARNINGS=\"ignore:the 'strict' parameter::urllib3.poolmanager\""
   ]

--- a/terraform/via-operator-oci-hpc-oke-utils.tf
+++ b/terraform/via-operator-oci-hpc-oke-utils.tf
@@ -6,9 +6,9 @@ module "oci_hpc_oke_utils" {
   source = "./helm-module"
 
   bastion_host    = module.oke.bastion_public_ip
-  bastion_user    = var.bastion_user
+  bastion_user    = local.bastion_user
   operator_host   = module.oke.operator_private_ip
-  operator_user   = var.operator_user
+  operator_user   = local.operator_user
   ssh_private_key = tls_private_key.stack_key.private_key_openssh
 
   deployment_name = "oci-hpc-oke-utils"
@@ -16,7 +16,7 @@ module "oci_hpc_oke_utils" {
   helm_chart_path = "${path.module}/files/oci-hpc-oke-utils"
 
   pre_deployment_commands = [
-    "export PATH=$PATH:/home/${var.operator_user}/bin",
+    "export PATH=$PATH:/home/${local.operator_user}/bin",
     "export OCI_CLI_AUTH=instance_principal",
     "export PYTHONWARNINGS=\"ignore:the 'strict' parameter::urllib3.poolmanager\""
   ]


### PR DESCRIPTION
Fixes #224.

This PR allows Resource Manager users to select bastion and operator images instead of always using Ubuntu 22.04. It adds platform/custom image selection, image OCID or HTTP/HTTPS URI import, auto SSH user resolution (ubuntu for Ubuntu, opc for Oracle Linux), output metadata, and validation for missing custom images, invalid URI schemes, and invalid SSH users.

Validation: terraform fmt/validate passed; Resource Manager custom Oracle Linux image deployment passed with OKE v1.34.2; default Ubuntu/platform deployment passed with operator user ubuntu and Ubuntu 22.04.5 LTS; negative URI/user/missing-image validation passed; kubectl, helm, k9s, and OCI CLI instance-principal smoke tests passed. Validation stack was destroyed successfully with 0 managed resources remaining.