### PR TITLE
Use dynamic OKE Kubernetes version selectors

### DIFF
--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -1231,15 +1231,14 @@ variables:
     description: The Container Engine for Kubernetes cluster name.
     required: true
   kubernetes_version:
-    type: enum
+    type: oci:kubernetes:versions:id
     title: Kubernetes version
     description: The Kubernetes version for the created OKE cluster and managed nodes.
     required: true
-    default: "v1.35.2"
-    enum:
-      - "v1.35.2"
-      - "v1.34.2"
-      - "v1.33.10"
+    default: "v1.34.2"
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      clusterOptionId: "all"
   control_plane_allowed_cidrs:
     title: Kubernetes endpoint allowed CIDRs
     description: List of CIDR ranges for allowed Kubernetes endpoint communication.
@@ -1521,13 +1520,12 @@ variables:
   worker_ops_kubernetes_version:
     title: Kubernetes version
     description: Kubernetes version for the system worker pool. Defaults to the cluster version.
-    type: enum
+    type: oci:kubernetes:versions:id
     required: false
     default: ${kubernetes_version}
-    enum:
-      - "v1.35.2"
-      - "v1.34.2"
-      - "v1.33.10"
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      clusterOptionId: "all"
 
   # Workers - CPU pool
   worker_cpu_enabled:
@@ -1714,14 +1712,13 @@ variables:
   worker_cpu_kubernetes_version:
     title: Kubernetes version
     description: Kubernetes version for the CPU worker pool. Defaults to the cluster version.
-    type: enum
+    type: oci:kubernetes:versions:id
     required: false
     default: ${kubernetes_version}
     visible: ${worker_cpu_enabled}
-    enum:
-      - "v1.35.2"
-      - "v1.34.2"
-      - "v1.33.10"
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      clusterOptionId: "all"
 
   # Workers - GPU node-pool
   worker_gpu_enabled:
@@ -1833,14 +1830,13 @@ variables:
   worker_gpu_kubernetes_version:
     title: Kubernetes version
     description: Kubernetes version for the GPU worker pool. Defaults to the cluster version.
-    type: enum
+    type: oci:kubernetes:versions:id
     required: false
     default: ${kubernetes_version}
     visible: ${worker_gpu_enabled}
-    enum:
-      - "v1.35.2"
-      - "v1.34.2"
-      - "v1.33.10"
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      clusterOptionId: "all"
 
   # Workers - GPU Cluster-network
   worker_rdma_enabled:
@@ -1958,14 +1954,13 @@ variables:
   worker_rdma_kubernetes_version:
     title: Kubernetes version
     description: Kubernetes version for the GPU + RDMA worker pool. Defaults to the cluster version.
-    type: enum
+    type: oci:kubernetes:versions:id
     required: false
     default: ${kubernetes_version}
     visible: ${worker_rdma_enabled}
-    enum:
-      - "v1.35.2"
-      - "v1.34.2"
-      - "v1.33.10"
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      clusterOptionId: "all"
 
   # Workers - GPU Memory Cluster
   worker_gmc_enabled:
@@ -2006,14 +2001,13 @@ variables:
   worker_gmc_kubernetes_version:
     title: Kubernetes version
     description: Kubernetes version for the GPU Memory Cluster worker pool. Defaults to the cluster version.
-    type: enum
+    type: oci:kubernetes:versions:id
     required: false
     default: ${kubernetes_version}
     visible: ${worker_gmc_enabled}
-    enum:
-      - "v1.35.2"
-      - "v1.34.2"
-      - "v1.33.10"
+    dependsOn:
+      compartmentId: ${compartment_ocid}
+      clusterOptionId: "all"
   worker_gmc_image_id:
     title: Image
     description: Custom image OCID for the GPU Memory Cluster worker pool.


### PR DESCRIPTION
Fixes #222

## Summary

- Use OCI Resource Manager's dynamic Kubernetes version selector for the OKE cluster version.
- Default worker pool Kubernetes versions to the selected cluster Kubernetes version.
- Keep the stack edit/deploy experience aligned with the version that was actually deployed instead of reverting the displayed selector to the latest default.

## Validation

- Ran `terraform -chdir=terraform fmt -check -recursive`.
- Ran `terraform -chdir=terraform validate`.
- Deployed a Resource Manager stack from this branch with `kubernetes_version = v1.34.2`.
- Confirmed the OKE cluster, node pool, and worker node all reported Kubernetes `v1.34.2`.
- Destroyed the validation stack and deleted the validation compartment after testing.

## Notes

- This change is limited to `terraform/schema.yaml`.
- No IAM policy, Terraform resource, or runtime behavior changes are included.
