### PR TITLE
Bump alekc/kubectl to ~> 2.4.1 with lazy_load

### DIFF
--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -57,6 +57,9 @@ provider "kubectl" {
   cluster_ca_certificate = base64decode(local.cluster_ca_cert)
   tls_server_name        = trimsuffix(trimprefix(local.cluster_private_endpoint, "https://"), ":6443")
   apply_retry_count      = 30
+  # alekc/kubectl >= 2.3.0 validates the kube config eagerly at provider-configure
+  # time. On a fresh apply the OKE endpoint is not known yet, so defer the check.
+  lazy_load = true
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "oci"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.2.0"
+      version = "~> 2.4.1"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
Set `lazy_load = true` to restore 2.3.0 functionality with 2.4.1 and above.