### PR TITLE
Kueue destroy helper for ORM/local deployments + Prometheus stack version upgrade

### DIFF
--- a/terraform/files/kube-prometheus/values.yaml.tftpl
+++ b/terraform/files/kube-prometheus/values.yaml.tftpl
@@ -57,6 +57,8 @@ grafana:
     accessModes:
       - ReadWriteOnce
     size: 100Gi
+    persistentVolumeClaimRetentionPolicy:
+      whenDeleted: Delete
     finalizers:
       - kubernetes.io/pvc-protection
   sidecar:

--- a/terraform/schema.yaml
+++ b/terraform/schema.yaml
@@ -1365,7 +1365,7 @@ variables:
     title: Prometheus stack chart version
     type: string
     required: true
-    default: "86.2.2"
+    default: "87.2.1"
     visible: false
       # and:
       # - monitoring_advanced_options

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -362,7 +362,7 @@ variable "node_problem_detector_chart_version" {
 }
 
 variable "prometheus_stack_chart_version" {
-  default = "86.2.2"
+  default = "87.2.1"
   type    = string
 }
 

--- a/terraform/via-operator-kueue-predestroy-drain.tf
+++ b/terraform/via-operator-kueue-predestroy-drain.tf
@@ -4,7 +4,7 @@
 # Drain all Kueue CRs before the chart is uninstalled so the CRD cascade does not
 # hang on resource-in-use finalizers. Operator path only (drains over
 # bastion->operator SSH); ORM/local use wait = false on helm_release.kueue.
-resource "null_resource" "kueue_predestroy_drain" {
+resource "null_resource" "kueue_predestroy_drain_via_operator" {
   count = alltrue([var.install_kueue, local.deploy_from_operator]) ? 1 : 0
 
   triggers = {

--- a/terraform/via-orm-kueue-predestroy-drain.tf
+++ b/terraform/via-orm-kueue-predestroy-drain.tf
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 Oracle Corporation and/or its affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# Drain all Kueue CRs before the chart is uninstalled so the CRD cascade does not
+# hang on resource-in-use finalizers.
+
+locals {
+  kube_config = module.oke.cluster_kubeconfig
+  patched_kube_config = merge(local.kube_config, {
+    "clusters" = [
+      for c in local.kube_config["clusters"] : {
+        "name"    = c["name"]
+        "cluster" = {
+          "server"                   = local.deploy_from_orm ? local.cluster_orm_endpoint : ( local.deploy_from_local ? local.cluster_public_endpoint : "not-defined" )
+          "insecure-skip-tls-verify" = true
+        }
+      }
+    ]
+  })
+}
+
+resource "null_resource" "kueue_predestroy_drain_via_orm" {
+  count = alltrue([var.install_kueue, local.deploy_from_local || local.deploy_from_orm]) ? 1 : 0
+
+  triggers = {
+    kubeconfig   = yamlencode(local.patched_kube_config)
+    drain_script = file("${path.module}/files/kueue/predestroy-drain.sh")
+  }
+
+  provisioner "local-exec" {
+    when       = destroy
+    on_failure = continue
+    interpreter = ["/bin/bash", "-c"]
+    command = <<-EOT
+      TMPKUBE="$(mktemp --suffix=.yaml)"
+      printf '%s' '${self.triggers.kubeconfig}' > "$TMPKUBE"
+      export KUBECONFIG="$TMPKUBE"
+      export PYTHONWARNINGS="ignore:the 'strict' parameter::urllib3.poolmanager"
+      printf '%s' '${base64encode(self.triggers.drain_script)}' | base64 -d > /tmp/kueue-predestroy-drain.sh
+      bash /tmp/kueue-predestroy-drain.sh
+    EOT
+  }
+
+  lifecycle {
+    ignore_changes = [
+      triggers["kubeconfig"],
+      triggers["drain_script"]
+    ]
+  }
+
+  depends_on = [ helm_release.kueue ]
+}


### PR DESCRIPTION
- Add support for kueue resources cleanup on destroy for local or ORM deployments.
- Upgrade the prometheus stack version to support `persistentVolumeClaimRetentionPolicy` for Grafana PVC.