### PR TITLE
setting operator allow image drift to true

### DIFF
--- a/terraform/oke-cluster.tf
+++ b/terraform/oke-cluster.tf
@@ -294,6 +294,7 @@ module "oke" {
   operator_install_oci_cli_from_repo = true
   operator_install_k9s               = true
   operator_install_kubectx           = true
+  operator_allow_image_drift         = var.operator_allow_image_drift
   operator_shape = {
     shape            = var.operator_shape_name
     ocpus            = lookup(local.operator_denseio_ocpus, var.operator_shape_name, var.operator_shape_ocpus)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -267,6 +267,11 @@ variable "operator_image_use_uri" {
   description = "Import the operator custom image from an Object Storage URI."
   type        = bool
 }
+variable "operator_allow_image_drift" {
+  default     = true
+  description = "Allow the operator instance image to drift from the latest resolved image without forcing replacement."
+  type        = bool
+}
 variable "operator_user" {
   default     = "auto"
   description = "The user used to SSH into the operator instance. Set to 'auto' to use opc for Oracle Linux images and ubuntu for all other images, or override with your own username."


### PR DESCRIPTION
Setting operator allow image drift to true so the stack won't redeploy operator by default when terraform resolves the image to the latest.  