### PR TITLE
Update NCCL tests image to CUDA 13.3 and support Open MPI 5

### DIFF
--- a/docker/nccl-tests/Dockerfile
+++ b/docker/nccl-tests/Dockerfile
@@ -1,24 +1,74 @@
-ARG PYTORCH_IMAGE_TAG
-ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:${PYTORCH_IMAGE_TAG}
+ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:26.06-cuda13.3-inference-devel-ubuntu24.04
+ARG INSTALL_LATEST_NCCL_VERSION=true
 
 FROM ${BASE_IMAGE}
 
-RUN apt-get update && apt-get install -y \
+ARG INSTALL_LATEST_NCCL_VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     infiniband-diags \
     openssh-server \
     kmod \
     wget \
-&& rm -rf /var/lib/apt/lists/*
+    ca-certificates \
+    iproute2 \
+    net-tools \
+    iputils-ping \
+    curl \
+    tcpdump \
+    ethtool \
+    lsof \
+    pciutils \
+    numactl \
+    iperf3 \
+    autoconf \
+    automake \
+    libtool \
+    libpci-dev \
+    git \
+    && if [ "${INSTALL_LATEST_NCCL_VERSION}" = "true" ]; then \
+        CUDA_ARCH=$([ "$(dpkg --print-architecture)" = "amd64" ] && echo "x86_64" || echo "sbsa") \
+        && wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/${CUDA_ARCH}/cuda-keyring_1.1-1_all.deb \
+        && dpkg -i cuda-keyring_1.1-1_all.deb \
+        && rm cuda-keyring_1.1-1_all.deb \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends \
+            libnccl2 \
+            libnccl-dev; \
+    fi \
+    && rm -rf /var/lib/apt/lists/*
 
-ARG NCCL_VERSION
-ARG NCCL_TESTS_VERSION
+ARG NCCL_TESTS_VERSION=2.19.6
+ARG NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_90,code=sm_90 -gencode=arch=compute_100,code=sm_100 -gencode=arch=compute_120,code=sm_120 -gencode=arch=compute_120,code=compute_120"
+WORKDIR /workspace
 
-RUN wget -qO- https://github.com/NVIDIA/nccl/archive/refs/tags/v${NCCL_VERSION}.tar.gz | tar -xvz && \
-    cd nccl-${NCCL_VERSION} && \
-    make -j src.build
+RUN git clone --depth 1 --branch v${NCCL_TESTS_VERSION} https://github.com/NVIDIA/nccl-tests.git nccl-tests-${NCCL_TESTS_VERSION} \
+    && cd nccl-tests-${NCCL_TESTS_VERSION} \
+    && make -j MPI=1 MPI_HOME=/usr/local/mpi NVCC_GENCODE="${NVCC_GENCODE}" \
+    && ln -s /workspace/nccl-tests-${NCCL_TESTS_VERSION} /workspace/nccl-tests
 
-RUN wget -qO- https://github.com/NVIDIA/nccl-tests/archive/refs/tags/v${NCCL_TESTS_VERSION}.tar.gz | tar -xvz && \
-    cd nccl-tests-${NCCL_TESTS_VERSION} && \
-    make -j MPI=1 MPI_HOME=/usr/local/mpi NCCL_HOME=/workspace/nccl-${NCCL_VERSION}/build && \
-    ln -s /workspace/nccl-tests-${NCCL_TESTS_VERSION} /workspace/nccl-tests
+ARG PERFTEST_VERSION=perftest-26.01.5
+RUN LIB_DIR="/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+    && for lib in libibverbs.so.1 librdmacm.so.1 libibumad.so.3 libmlx5.so.1 libefa.so.1; do \
+        base=$(echo $lib | sed 's/\.so\..*/\.so/'); \
+        [ -e "$LIB_DIR/$lib" ] && ln -sf "$LIB_DIR/$lib" "$LIB_DIR/$base" || true; \
+    done \
+    && git clone --depth 1 --branch ${PERFTEST_VERSION} https://github.com/linux-rdma/perftest.git /tmp/perftest \
+    && cd /tmp/perftest \
+    && ./autogen.sh \
+    && ./configure --prefix=/usr/local CUDA_H_PATH=/usr/local/cuda/include/cuda.h --enable-cuda --with-cuda=/usr/local/cuda --enable-mpi --with-mpi=/usr/local/mpi \
+    && make -j \
+    && make install \
+    && rm -rf /tmp/perftest
+
+RUN sed -i 's/[ #]\(.*StrictHostKeyChecking \).*/ \1no/g' /etc/ssh/ssh_config && \
+    echo "    UserKnownHostsFile /dev/null" >> /etc/ssh/ssh_config && \
+    sed -i 's/#\(StrictModes \).*/\1no/g' /etc/ssh/sshd_config && \
+    mkdir /var/run/sshd -p
+
+COPY --from=ghcr.io/huggingface/gpu-fryer:1.2.0@sha256:aaaf8dab4caf257448204d4ac66e1b04a37768849a9e8d225f431a01958b4ef7 /usr/local/bin/gpu-fryer /usr/local/bin/gpu-fryer
+COPY --from=ghcr.io/astral-sh/uv:0.11.23@sha256:d0a0a753ab981624b49c97abc98821c1c09f4ca69d1ef5cee69c501be3d88479 /uv /usr/local/bin/uv
+
+RUN curl -o /usr/sbin/ibdev2netdev https://raw.githubusercontent.com/Mellanox/container_scripts/refs/heads/master/ibdev2netdev && \
+    chmod +x /usr/sbin/ibdev2netdev

--- a/docker/nccl-tests/README.md
+++ b/docker/nccl-tests/README.md
@@ -1,11 +1,60 @@
-# Building the NCCL tests container
+# nccl-tests
 
-You can change the values of the variables based on the version combination you want to have in your image.
+Docker images for running [NVIDIA NCCL Tests](https://github.com/NVIDIA/nccl-tests), built with MPI support. A single `Dockerfile` targets any CUDA version — select it via the `BASE_IMAGE` build argument.
 
+| CUDA | `BASE_IMAGE` |
+|---|---|
+| 13.3 (default) | `nvcr.io/nvidia/cuda-dl-base:26.06-cuda13.3-inference-devel-ubuntu24.04` |
+| 12.9 | `nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04` |
+
+## Build arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `BASE_IMAGE` | cuda13.3 (see above) | Base image to build from — sets the CUDA version |
+| `NCCL_TESTS_VERSION` | `2.19.6` | nccl-tests git tag to build |
+| `INSTALL_LATEST_NCCL_VERSION` | `true` | When `true`, adds the NVIDIA CUDA apt repo and installs the latest available `libnccl2` and `libnccl-dev`, overriding the version bundled in the base image |
+
+## Build examples
+
+### Single-arch
+
+```bash
+# Default — cuda13.3 base, latest NCCL from NVIDIA apt repo
+docker build -t nccl-tests:cuda13.3 .
+
+# cuda12.9 — select a different base image
+docker build \
+  --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 \
+  -t nccl-tests:cuda12.9 .
+
+# NCCL version from the base image (skip the apt-repo install)
+docker build \
+  --build-arg INSTALL_LATEST_NCCL_VERSION=false \
+  -t nccl-tests:cuda13.3-base-nccl .
 ```
-docker build -t nccl-tests \
---build-arg PYTORCH_IMAGE_TAG=25.03-py3 \
---build-arg NCCL_VERSION=2.26.2-1 \
---build-arg NCCL_TESTS_VERSION=2.14.1 \
---pull .
+
+### Multi-arch (amd64 + arm64/sbsa)
+
+Requires a buildx builder with multi-platform support:
+
+```bash
+docker buildx create --use --name multiarch-builder
+
+# Build and push multi-arch manifest (cuda13.3 default)
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t <registry>/nccl-tests:cuda13.3 \
+  --push .
+
+# cuda12.9
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --build-arg BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.06-cuda12.9-devel-ubuntu24.04 \
+  -t <registry>/nccl-tests:cuda12.9 \
+  --push .
 ```
+
+The NCCL install step automatically selects the correct apt repo path (`x86_64` for amd64, `sbsa` for arm64).
+- `ibdev2netdev` installed to `/usr/sbin/ibdev2netdev`
+- Standard network/RDMA diagnostic tools: `infiniband-diags`, `iperf3`, `ethtool`, `tcpdump`, `pciutils`, `numactl`

--- a/docs/running-nccl-rccl-tests-with-kueue.md
+++ b/docs/running-nccl-rccl-tests-with-kueue.md
@@ -23,7 +23,7 @@ helm install kueue oci://registry.k8s.io/kueue/charts/kueue --version="0.18.2" -
 ### NCCL Tests
 | Image Tag                                                                 | CUDA   |
 |---------------------------------------------------------------------------|--------|
-| iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1 | 13.1.1 |
+| iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0 | 13.3.0 |
 | iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-12.9.1-ubuntu-24.04-nccl-2.29.3-020926.1 | 12.9.1 |
 
 ### RCCL Tests

--- a/manifests/active-health-checks/active-health-checks-rccl-tests.yaml
+++ b/manifests/active-health-checks/active-health-checks-rccl-tests.yaml
@@ -207,8 +207,6 @@ data:
               dnsPolicy: ClusterFirstWithHostNet
               restartPolicy: OnFailure
               terminationGracePeriodSeconds: 2
-              tolerations:
-              - { key: amd.com/gpu, operator: Exists }
               containers:
               - name: mpi-worker
                 image: iad.ocir.io/idxzjcdglx2s/rccl-tests:rocm-7.0.2-rccl-2.26.6-ubuntu22.04-102025.1
@@ -430,4 +428,3 @@ spec:
                   items:
                   - key: job.yaml
                     path: bm-gpu-mi300x-8.yaml
-

--- a/manifests/nccl-tests/kueue/BM.GPU.A100-v2.8.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.A100-v2.8.yaml
@@ -57,10 +57,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 set -e -o pipefail; trap 'exit 1' SIGINT
@@ -73,7 +78,7 @@ spec:
                 done
                 echo "All workers are ready!"
                 mpirun --allow-run-as-root \
-                  -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" \
+                  -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                   -mca coll_hcoll_enable 0 \
                   -np $NP -npernode $NUM_GPUS --bind-to numa \
                   -x NCCL_DEBUG=WARN \
@@ -113,7 +118,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.B200.8.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.B200.8.yaml
@@ -57,10 +57,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 NUM_GPUS=8
@@ -72,7 +77,7 @@ spec:
                 done
                 echo "All workers are ready!"
                 mpirun --allow-run-as-root \
-                -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" \
+                -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                 -mca coll_hcoll_enable 0 \
                 -np $NP -npernode $NUM_GPUS --bind-to numa \
                 -x NCCL_DEBUG=WARN \
@@ -116,7 +121,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.B300.8.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.B300.8.yaml
@@ -57,10 +57,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 NUM_GPUS=8
@@ -72,7 +77,7 @@ spec:
                 done
                 echo "All workers are ready!"
                 mpirun --allow-run-as-root \
-                -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" \
+                -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                 -mca coll_hcoll_enable 0 \
                 -np $NP -npernode $NUM_GPUS --bind-to numa \
                 -x NCCL_DEBUG=WARN \
@@ -116,7 +121,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.B4.8.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.B4.8.yaml
@@ -57,10 +57,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 set -e -o pipefail; trap 'exit 1' SIGINT
@@ -73,7 +78,7 @@ spec:
                 done
                 echo "All workers are ready!"
                 mpirun --allow-run-as-root \
-                  -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" \
+                  -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                   -mca coll_hcoll_enable 0 \
                   -np $NP -npernode $NUM_GPUS --bind-to numa \
                   -x NCCL_DEBUG=WARN \
@@ -113,7 +118,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.GB200-v2.4.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.GB200-v2.4.yaml
@@ -67,10 +67,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 NUM_GPUS=4
@@ -81,7 +86,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root -mca plm_rsh_args "-p 2222" \
+                mpirun --allow-run-as-root -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                 --bind-to none \
                 --map-by ppr:4:node \
                 --mca coll ^hcoll \
@@ -119,7 +124,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.GB200-v3.4.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.GB200-v3.4.yaml
@@ -67,10 +67,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 NUM_GPUS=4
@@ -85,7 +90,7 @@ spec:
                         -x UCX_TLS=tcp \
                         -x UCX_NET_DEVICES=eth0 \
                         -mca coll ^hcoll \
-                        -mca plm_rsh_args "-p 2222" \
+                        -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                         -mca btl_tcp_if_include eth0 \
                         --allow-run-as-root \
                         -x NCCL_IB_TIMEOUT=22 \
@@ -130,7 +135,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.GB200.4.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.GB200.4.yaml
@@ -67,10 +67,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 NUM_GPUS=4
@@ -81,7 +86,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root -mca plm_rsh_args "-p 2222" \
+                mpirun --allow-run-as-root -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                 --bind-to none \
                 --map-by ppr:4:node \
                 --mca coll ^hcoll \
@@ -119,7 +124,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.GB300.4.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.GB300.4.yaml
@@ -67,10 +67,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 NUM_GPUS=4
@@ -83,7 +88,7 @@ spec:
                 echo "All workers are ready!"
                 mpirun --bind-to numa \
                         --allow-run-as-root \
-                        -mca plm_rsh_args "-p 2222" \
+                        -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                         --mca pml ucx \
                         --mca coll ^hcoll \
                         -x NCCL_DEBUG=WARN \
@@ -132,7 +137,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.H100.8.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.H100.8.yaml
@@ -57,10 +57,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 NUM_GPUS=8
@@ -72,7 +77,7 @@ spec:
                 done
                 echo "All workers are ready!"
                 mpirun --allow-run-as-root \
-                -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" \
+                -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                 -mca coll_hcoll_enable 0 \
                 -np $NP -npernode $NUM_GPUS --bind-to numa \
                 -x NCCL_DEBUG=WARN \
@@ -116,7 +121,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU.H200.8.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU.H200.8.yaml
@@ -57,10 +57,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 NUM_GPUS=8
@@ -72,7 +77,7 @@ spec:
                 done
                 echo "All workers are ready!"
                 mpirun --allow-run-as-root \
-                -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" \
+                -mca coll ^hcoll  -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                 -mca coll_hcoll_enable 0 \
                 -np $NP -npernode $NUM_GPUS --bind-to numa \
                 -x NCCL_DEBUG=WARN \
@@ -116,7 +121,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/BM.GPU4.8.yaml
+++ b/manifests/nccl-tests/kueue/BM.GPU4.8.yaml
@@ -57,10 +57,15 @@ spec:
           dnsPolicy: ClusterFirstWithHostNet
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             ports:
             - { name: mpijob-port, containerPort: 2222, protocol: TCP }
             command: ["bash", "-c"]
+            # Open MPI 5 reads the worker ssh port only from this env var (PRRTE ignores -mca plm_rsh_args).
+            # Open MPI 4 does not read PRTE_MCA_* and uses -mca plm_rsh_args from the mpirun command line.
+            env:
+            - name: PRTE_MCA_plm_ssh_args
+              value: "-p 2222"
             args:
               - |
                 set -e -o pipefail; trap 'exit 1' SIGINT
@@ -73,7 +78,7 @@ spec:
                 done
                 echo "All workers are ready!"
                 mpirun --allow-run-as-root \
-                  -mca coll ^hcoll -mca plm_rsh_args "-p 2222" \
+                  -mca coll ^hcoll -mca plm_rsh_args "-p 2222" --hostfile /etc/mpi/hostfile \
                   -mca coll_hcoll_enable 0 \
                   -np $NP -npernode $NUM_GPUS --bind-to numa \
                   -x NCCL_DEBUG=WARN \
@@ -113,7 +118,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.A100-v2.8.yaml
+++ b/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.A100-v2.8.yaml
@@ -57,7 +57,7 @@ spec:
         spec:
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command: ["bash", "-c"]
             args:
               - |
@@ -70,7 +70,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root \
+                mpirun --allow-run-as-root --hostfile /etc/mpi/hostfile \
                   -mca coll ^hcoll \
                   -mca coll_hcoll_enable 0 \
                   -np $NP -npernode $NUM_GPUS --bind-to numa \
@@ -109,7 +109,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.B200.8.yaml
+++ b/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.B200.8.yaml
@@ -57,7 +57,7 @@ spec:
         spec:
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command: ["bash", "-c"]
             args:
               - |
@@ -69,7 +69,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root \
+                mpirun --allow-run-as-root --hostfile /etc/mpi/hostfile \
                 -mca coll ^hcoll \
                 -mca coll_hcoll_enable 0 \
                 -np $NP -npernode $NUM_GPUS --bind-to numa \
@@ -112,7 +112,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.B300.8.yaml
+++ b/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.B300.8.yaml
@@ -57,7 +57,7 @@ spec:
         spec:
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command: ["bash", "-c"]
             args:
               - |
@@ -69,7 +69,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root \
+                mpirun --allow-run-as-root --hostfile /etc/mpi/hostfile \
                 -mca coll ^hcoll \
                 -mca coll_hcoll_enable 0 \
                 -np $NP -npernode $NUM_GPUS --bind-to numa \
@@ -112,7 +112,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.B4.8.yaml
+++ b/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.B4.8.yaml
@@ -57,7 +57,7 @@ spec:
         spec:
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command: ["bash", "-c"]
             args:
               - |
@@ -70,7 +70,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root \
+                mpirun --allow-run-as-root --hostfile /etc/mpi/hostfile \
                   -mca coll ^hcoll \
                   -mca coll_hcoll_enable 0 \
                   -np $NP -npernode $NUM_GPUS --bind-to numa \
@@ -109,7 +109,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.H100.8.yaml
+++ b/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.H100.8.yaml
@@ -57,7 +57,7 @@ spec:
         spec:
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command: ["bash", "-c"]
             args:
               - |
@@ -69,7 +69,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root \
+                mpirun --allow-run-as-root --hostfile /etc/mpi/hostfile \
                 -mca coll ^hcoll \
                 -mca coll_hcoll_enable 0 \
                 -np $NP -npernode $NUM_GPUS --bind-to numa \
@@ -112,7 +112,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.H200.8.yaml
+++ b/manifests/nccl-tests/kueue/virtual-functions/BM.GPU.H200.8.yaml
@@ -57,7 +57,7 @@ spec:
         spec:
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command: ["bash", "-c"]
             args:
               - |
@@ -69,7 +69,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root \
+                mpirun --allow-run-as-root --hostfile /etc/mpi/hostfile \
                 -mca coll ^hcoll \
                 -mca coll_hcoll_enable 0 \
                 -np $NP -npernode $NUM_GPUS --bind-to numa \
@@ -112,7 +112,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/nccl-tests/kueue/virtual-functions/BM.GPU4.8.yaml
+++ b/manifests/nccl-tests/kueue/virtual-functions/BM.GPU4.8.yaml
@@ -57,7 +57,7 @@ spec:
         spec:
           containers:
           - name: mpi-launcher
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command: ["bash", "-c"]
             args:
               - |
@@ -70,7 +70,7 @@ spec:
                   sleep 5
                 done
                 echo "All workers are ready!"
-                mpirun --allow-run-as-root \
+                mpirun --allow-run-as-root --hostfile /etc/mpi/hostfile \
                   -mca coll ^hcoll \
                   -mca coll_hcoll_enable 0 \
                   -np $NP -npernode $NUM_GPUS --bind-to numa \
@@ -109,7 +109,7 @@ spec:
               privileged: true
               capabilities:
                 add: ["IPC_LOCK"]
-            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.1.1-ubuntu-24.04-nccl-2.29.3-020926.1
+            image: iad.ocir.io/idxzjcdglx2s/nccl-tests:cuda-13.3.0-ubuntu-24.04-nccl-2.30.4-071626.0
             command:
               - /bin/bash
               - -c

--- a/manifests/rccl-tests/kueue/BM.GPU.MI300X.8.yaml
+++ b/manifests/rccl-tests/kueue/BM.GPU.MI300X.8.yaml
@@ -162,8 +162,5 @@ spec:
             volumeMounts:
             - { mountPath: /dev/shm, name: shm }
             workingDir: /workspace
-          tolerations:
-          - { key: amd.com/gpu, operator: Exists }
           volumes:
           - { name: shm, emptyDir: { medium: Memory, sizeLimit: 128Gi }}
-

--- a/manifests/rccl-tests/kueue/BM.GPU.MI355X-v1.8.yaml
+++ b/manifests/rccl-tests/kueue/BM.GPU.MI355X-v1.8.yaml
@@ -157,7 +157,5 @@ spec:
             volumeMounts:
             - { mountPath: /dev/shm, name: shm }
             workingDir: /workspace
-          tolerations:
-          - { key: amd.com/gpu, operator: Exists }
           volumes:
           - { name: shm, emptyDir: { medium: Memory, sizeLimit: 128Gi }}

--- a/manifests/rccl-tests/kueue/BM.GPU.MI355X.8.yaml
+++ b/manifests/rccl-tests/kueue/BM.GPU.MI355X.8.yaml
@@ -185,7 +185,5 @@ spec:
               volumeMounts:
                 - { mountPath: /dev/shm, name: shm }
               workingDir: /workspace
-          tolerations:
-            - { key: amd.com/gpu, operator: Exists }
           volumes:
             - { name: shm, emptyDir: { medium: Memory, sizeLimit: 128Gi }}

--- a/manifests/rccl-tests/kueue/virtual-functions/BM.GPU.MI300X.8.yaml
+++ b/manifests/rccl-tests/kueue/virtual-functions/BM.GPU.MI300X.8.yaml
@@ -160,8 +160,5 @@ spec:
             volumeMounts:
             - { mountPath: /dev/shm, name: shm }
             workingDir: /workspace
-          tolerations:
-          - { key: amd.com/gpu, operator: Exists }
           volumes:
           - { name: shm, emptyDir: { medium: Memory, sizeLimit: 128Gi }}
-

--- a/manifests/rccl-tests/kueue/virtual-functions/BM.GPU.MI355X-v1.8.yaml
+++ b/manifests/rccl-tests/kueue/virtual-functions/BM.GPU.MI355X-v1.8.yaml
@@ -155,7 +155,5 @@ spec:
             volumeMounts:
             - { mountPath: /dev/shm, name: shm }
             workingDir: /workspace
-          tolerations:
-          - { key: amd.com/gpu, operator: Exists }
           volumes:
           - { name: shm, emptyDir: { medium: Memory, sizeLimit: 128Gi }}


### PR DESCRIPTION
The new HPC-X versions come with Open MPI 5. Updating the Nvidia NCCL tests manifests to support both OMPI 4 and OMPI 5.