### PR TITLE
Make the labeler contoller deployment comply with drain requests

### DIFF
--- a/terraform/files/oci-hpc-oke-utils/values.yaml
+++ b/terraform/files/oci-hpc-oke-utils/values.yaml
@@ -41,7 +41,10 @@ labeler:
     nodeSelectorLabel: ""
     nodeSelector: {}
     tolerations:
-      - operator: Exists
+      - key: nvidia.com/gpu
+        operator: Exists
+      - key: amd.com/gpu
+        operator: Exists
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
Replace global with explicit tolerations for the node labeler controller.