### PR TITLE
Order Kube Prometheus stack after Kueue webhook readiness

### DIFF
--- a/docs/deploying-monitoring-stack-manually.md
+++ b/docs/deploying-monitoring-stack-manually.md
@@ -1285,6 +1285,31 @@ kubectl logs -n ${MONITORING_NAMESPACE} -l app.kubernetes.io/name=oke-ons-webhoo
 - Check logs for any authentication errors
 - Verify `GRAFANA_INITIAL_PASSWORD` is correct and base64-encoded
 
+### Terraform Apply Fails With "cannot re-use a name that is still in use"
+
+**Issue**: A Terraform apply that installs `kube-prometheus-stack` fails. One known cause is the Kueue webhook rejecting the chart's admission hook Job with `no endpoints available for service "kueue-webhook-service"`. The next apply then fails with:
+
+```
+Error: cannot re-use a name that is still in use
+```
+
+**Cause**: The Helm provider does not save a release with a failed status to the Terraform state. Helm keeps the failed release. The next apply tries to install a new release with the same name.
+
+This applies to local and OCI Resource Manager deployments, which use the Helm provider. Operator-based deployments use `helm upgrade --install`, which can retry the failed release.
+
+**Solution**:
+1. Confirm that the release is in the failed state:
+   ```bash
+   helm list -n ${MONITORING_NAMESPACE} --failed
+   ```
+2. Uninstall the failed release:
+   ```bash
+   helm uninstall kube-prometheus-stack -n ${MONITORING_NAMESPACE} --wait --timeout 5m
+   ```
+3. Run the Terraform apply again.
+
+For Resource Manager stacks with a private cluster, run the `helm` commands from the operator host.
+
 ## Cleanup
 
 To remove the entire monitoring stack:

--- a/terraform/via-operator-helm-deployments.tf
+++ b/terraform/via-operator-helm-deployments.tf
@@ -186,7 +186,10 @@ module "kube_prometheus_stack" {
       } : {})
     }
   ) : ""
-  depends_on = [module.ingress]
+  # Kueue's mutating webhook intercepts Job creates cluster-wide; the chart's
+  # admission hook Jobs fail with "no endpoints available for service
+  # kueue-webhook-service" while Kueue is still starting.
+  depends_on = [module.ingress, module.kueue]
 }
 
 

--- a/terraform/via-provider-kube-prometheus-stack.tf
+++ b/terraform/via-provider-kube-prometheus-stack.tf
@@ -3,9 +3,14 @@
 
 resource "helm_release" "prometheus" {
   count = alltrue([var.install_monitoring, var.install_node_problem_detector_kube_prometheus_stack, local.deploy_from_local || local.deploy_from_orm]) ? 1 : 0
+  # Kueue's mutating webhook intercepts Job creates cluster-wide; the chart's
+  # admission hook Jobs fail with "no endpoints available for service
+  # kueue-webhook-service" while Kueue is still starting.
   depends_on = [
     helm_release.ingress,
-    time_sleep.wait_for_ingress_lb
+    time_sleep.wait_for_ingress_lb,
+    helm_release.kueue,
+    kubectl_manifest.kueue_webhook_probe,
   ]
   namespace  = var.monitoring_namespace
   name       = "kube-prometheus-stack"


### PR DESCRIPTION
Kueue's Job webhook rejects the chart's hook Jobs while Kueue is starting. Also document recovery from the failed release.